### PR TITLE
move mod admin helpers to backend ts

### DIFF
--- a/backend/ts/mod_admin.ts
+++ b/backend/ts/mod_admin.ts
@@ -5,52 +5,52 @@
 
 export type UUID = string;
 
-export async function getModerationQueue(supabase) {
+export async function getModerationQueue(supabase: any) {
   return await supabase.rpc('get_moderation_queue');
 }
 
 // Threads
-export async function lockThread(supabase, threadId: UUID) {
+export async function lockThread(supabase: any, threadId: UUID) {
   return await supabase.rpc('lock_thread', { p_thread: threadId, p_locked: true });
 }
-export async function unlockThread(supabase, threadId: UUID) {
+export async function unlockThread(supabase: any, threadId: UUID) {
   return await supabase.rpc('unlock_thread', { p_thread: threadId });
 }
-export async function toggleThreadLock(supabase, threadId: UUID) {
+export async function toggleThreadLock(supabase: any, threadId: UUID) {
   return await supabase.rpc('toggle_thread_lock', { p_thread: threadId });
 }
-export async function deleteThread(supabase, threadId: UUID) {
+export async function deleteThread(supabase: any, threadId: UUID) {
   return await supabase.rpc('delete_thread', { p_thread: threadId });
 }
 
 // Posts
-export async function editPostText(supabase, postId: UUID, content: string) {
+export async function editPostText(supabase: any, postId: UUID, content: string) {
   return await supabase.rpc('edit_post_text', { p_post: postId, p_content: content });
 }
-export async function deleteFlaggedPost(supabase, postId: UUID) {
+export async function deleteFlaggedPost(supabase: any, postId: UUID) {
   return await supabase.rpc('delete_flagged_post', { p_post: postId });
 }
 
 // Flags
-export async function deleteFlag(supabase, flagId: UUID) {
+export async function deleteFlag(supabase: any, flagId: UUID) {
   return await supabase.rpc('delete_flag', { p_flag: flagId });
 }
-export async function clearFlagsForPost(supabase, postId: UUID) {
+export async function clearFlagsForPost(supabase: any, postId: UUID) {
   return await supabase.rpc('clear_flags_for_post', { p_post: postId });
 }
-export async function listReportedPosts(supabase) {
+export async function listReportedPosts(supabase: any) {
   return await supabase.rpc('list_reported_posts');
 }
 
 // Membership (admin or owner per RLS)
-export async function adminAddMember(supabase, nestId: UUID, profileId: UUID) {
+export async function adminAddMember(supabase: any, nestId: UUID, profileId: UUID) {
   return await supabase.rpc('admin_add_member', { p_nest: nestId, p_profile: profileId });
 }
-export async function adminRemoveMember(supabase, nestId: UUID, profileId: UUID) {
+export async function adminRemoveMember(supabase: any, nestId: UUID, profileId: UUID) {
   return await supabase.rpc('admin_remove_member', { p_nest: nestId, p_profile: profileId });
 }
 
 // Roles (admin only)
-export async function adminSetUserRole(supabase, targetUserId: UUID, role: 'user' | 'moderator' | 'admin') {
+export async function adminSetUserRole(supabase: any, targetUserId: UUID, role: 'user' | 'moderator' | 'admin') {
   return await supabase.rpc('admin_set_user_role', { p_target: targetUserId, p_role: role });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
+  "include": ["client/src/**/*", "shared/**/*", "server/**/*", "backend/ts/**/*"],
   "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
   "compilerOptions": {
     "incremental": true,


### PR DESCRIPTION
## Summary
- move Supabase moderation helpers into backend/ts
- include backend/ts in tsconfig for type checking
- annotate supabase parameter types for strict TS config

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a7567e10483219dade91c2896039f