### PR TITLE
Add Supabase dev utilities and scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,19 @@
   "description": "A neurodivergent-friendly mood tracking app with animal companions. Built with Vite, React, Tailwind, Express, and Drizzle ORM.",
   "engines": { "node": ">=18 <20" },
   "scripts": {
-    "dev": "NODE_ENV=development tsx server/index.ts",
+    "dev": "concurrently \"npm:dev:web\" \"npm:dev:supabase\"",
+    "dev:web": "vite",
+    "dev:supabase": "supabase start",
+    "dev:server": "NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "preview": "vite preview",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "test": "node --import tsx --test server/**/*.test.ts",
-    "db:push": "drizzle-kit push"
+    "db:reset": "supabase db reset",
+    "db:push": "supabase db push",
+    "db:push:drizzle": "drizzle-kit push",
+    "db:seed": "psql \"$SUPABASE_DB_URL\" -f supabase/seed/dev_seed.sql"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -105,7 +111,8 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "concurrently": "^9.0.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"


### PR DESCRIPTION
## Summary
- add Vite and Supabase dev scripts and run them concurrently
- expose DB management scripts for reset, push, and seeding
- include `concurrently` as a dev dependency

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689a7573bca883219c645a473f616d8e