### PR TITLE
Add user data export and account deletion RPCs

### DIFF
--- a/backend/ts/user_privacy.ts
+++ b/backend/ts/user_privacy.ts
@@ -1,0 +1,11 @@
+// Supabase v2 client helpers for user privacy actions
+// Usage: import { createClient } from '@supabase/supabase-js'
+// const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_OR_SERVICE_KEY)
+
+export async function exportUserData(supabase: any) {
+  return await supabase.rpc('export_user_data');
+}
+
+export async function deleteUserAccount(supabase: any) {
+  return await supabase.rpc('delete_user_account');
+}

--- a/docs/privacy-security.md
+++ b/docs/privacy-security.md
@@ -28,6 +28,22 @@ Cozy Critter is built with privacy by default.
 - You can export your data (see [backup-export.md](./backup-export.md)).
 - Backups are plain JSON—keep them secure.
 
+## User Data Management (Supabase)
+
+For self-hosted deployments that include the Supabase backend, two RPCs help users manage their data:
+
+- `export_user_data` – returns a JSON document containing the user’s profile, posts, reactions, and nest memberships.
+- `delete_user_account` – removes the authenticated user and cascades deletes to related rows.
+
+Example usage with the provided TypeScript helpers:
+
+```ts
+import { exportUserData, deleteUserAccount } from '../backend/ts/user_privacy';
+
+const { data } = await exportUserData(supabase);
+await deleteUserAccount(supabase);
+```
+
 ## Reporting Issues
 
 - Privacy or security concern? Please open an issue or email the maintainer.

--- a/supabase/migrations/20250811_03_user_privacy_rpcs.sql
+++ b/supabase/migrations/20250811_03_user_privacy_rpcs.sql
@@ -1,0 +1,36 @@
+-- User privacy RPC functions
+
+/* =========================================================
+   Export user data
+========================================================= */
+create or replace function public.export_user_data()
+returns jsonb
+language sql
+security invoker as $$
+  select jsonb_build_object(
+    'profile', (select row_to_json(p) from public.profiles p where p.id = auth.uid()),
+    'posts', coalesce((select jsonb_agg(row_to_json(po)) from public.posts po where po.author_id = auth.uid()), '[]'::jsonb),
+    'reactions', coalesce((select jsonb_agg(row_to_json(r)) from public.reactions r where r.author_id = auth.uid()), '[]'::jsonb),
+    'memberships', coalesce((select jsonb_agg(row_to_json(m)) from public.nest_members m where m.profile_id = auth.uid()), '[]'::jsonb)
+  );
+$$;
+
+/* =========================================================
+   Delete user account
+========================================================= */
+create or replace function public.delete_user_account()
+returns void
+language sql
+security definer
+set search_path = public, auth as $$
+  delete from auth.users where id = auth.uid();
+$$;
+
+/* =========================================================
+   Grants
+========================================================= */
+revoke all on function public.export_user_data() from public;
+grant execute on function public.export_user_data() to authenticated;
+
+revoke all on function public.delete_user_account() from public;
+grant execute on function public.delete_user_account() to authenticated;


### PR DESCRIPTION
## Summary
- add export_user_data and delete_user_account RPC migrations
- expose TypeScript helpers for user privacy RPCs
- document how to export and delete user data via Supabase

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689a83fe80008321b7410219a37b4e12