### PR TITLE
feat: add anonymous post support

### DIFF
--- a/docs/mod-tools.md
+++ b/docs/mod-tools.md
@@ -37,7 +37,28 @@ Admins have moderator abilities plus membership and role control:
   await supabase.rpc('admin_remove_member', { p_nest: '<nest-id>', p_profile: '<profile-id>' });
   ```
 - Set a user's role
-  ```ts
-  await supabase.rpc('admin_set_user_role', { p_target: '<user-id>', p_role: 'moderator' });
-  ```
+```ts
+await supabase.rpc('admin_set_user_role', { p_target: '<user-id>', p_role: 'moderator' });
+```
+
+## Anonymous Posts
+
+Users can publish posts without revealing their identity.
+The `create_anonymous_post` RPC inserts a post with `is_anonymous` set and
+returns a temporary surrogate name for display.
+When a post is anonymous, non‑moderators see `author_id` as `null` via the
+`posts_redacted` view, while moderators and the original author retain full
+visibility.
+
+```ts
+await supabase.rpc('create_anonymous_post', {
+  p_thread: '<thread-id>',
+  p_content: 'Invisible critter here'
+});
+```
+
+**Limitations**
+
+- Surrogate names are not stored and cannot be regenerated.
+- Direct table reads require moderator privileges to reveal authors.
 

--- a/supabase/migrations/20250811_05_anonymous_posts.sql
+++ b/supabase/migrations/20250811_05_anonymous_posts.sql
@@ -1,0 +1,47 @@
+-- Add anonymous posting support
+alter table public.posts
+  add column is_anonymous boolean not null default false;
+
+-- View masking author_id when anonymous
+create or replace view public.posts_redacted as
+select
+  p.id,
+  p.thread_id,
+  case
+    when p.is_anonymous and not (public.is_moderator() or p.author_id = auth.uid())
+      then null
+      else p.author_id
+  end as author_id,
+  p.content,
+  p.created_at,
+  p.updated_at,
+  p.is_anonymous
+from public.posts p;
+
+-- Adjust privileges: use view for reads
+revoke select on public.posts from anon, authenticated;
+grant select on public.posts_redacted to anon, authenticated;
+
+-- RPC to create an anonymous post with surrogate name
+create or replace function public.create_anonymous_post(
+  p_thread uuid,
+  p_content text
+) returns table (
+  id uuid,
+  thread_id uuid,
+  content text,
+  created_at timestamptz,
+  surrogate_name text
+) language plpgsql
+security invoker as $$
+declare
+  v_post public.posts;
+  v_name text;
+begin
+  v_name := 'anon-' || substr(md5(random()::text),1,8);
+  insert into public.posts(thread_id, author_id, content, is_anonymous)
+  values (p_thread, auth.uid(), p_content, true)
+  returning * into v_post;
+  return query select v_post.id, v_post.thread_id, v_post.content, v_post.created_at, v_name;
+end;
+$$;


### PR DESCRIPTION
## Summary
- allow posts to be marked anonymous
- mask anonymous authors from general readers
- add `create_anonymous_post` RPC and docs

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689a883001ec8321bc2d3e89413c732e