### PR TITLE
feat: tighten audit logging middleware

### DIFF
--- a/backend/src/middleware/auditLogger.ts
+++ b/backend/src/middleware/auditLogger.ts
@@ -1,12 +1,57 @@
 import { Request, Response, NextFunction } from "express";
 import { supabase } from "../utils/supabase";
 
-export async function auditLogger(req: Request, res: Response, next: NextFunction) {
+const SENSITIVE_PATTERNS = [
+  /password/i,
+  /token/i,
+  /secret/i,
+  /key/i,
+  /auth/i,
+  /credential/i,
+  /session/i,
+];
+
+function maskSensitiveData(data: any): any {
+  if (data === null || typeof data !== "object") return data;
+  if (Array.isArray(data)) return data.map(maskSensitiveData);
+
+  const masked: Record<string, any> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (SENSITIVE_PATTERNS.some((pattern) => pattern.test(key))) {
+      masked[key] = "[REDACTED]";
+    } else {
+      masked[key] = maskSensitiveData(value);
+    }
+  }
+  return masked;
+}
+
+const MAX_LOG_LENGTH = 1000;
+
+export async function auditLogger(
+  req: Request,
+  _res: Response,
+  next: NextFunction
+) {
   const user = (req as any).user;
-  await supabase.from("mod_audit_log").insert({
-    actor_id: user.id,
-    action: `${req.method} ${req.originalUrl}`,
-    metadata: req.body,
-  });
+  const sanitizedBody = maskSensitiveData(req.body || {});
+  let metadata: any = sanitizedBody;
+
+  const metadataStr = JSON.stringify(sanitizedBody);
+  if (metadataStr.length > MAX_LOG_LENGTH) {
+    metadata = { truncated: true };
+  }
+
+  try {
+    await supabase.from("mod_audit_log").insert({
+      actor_id: user.id,
+      action: `${req.method} ${req.originalUrl}`,
+      metadata,
+    });
+  } catch (error) {
+    console.error("Failed to write audit log", error);
+  }
+
   next();
 }
+


### PR DESCRIPTION
## Summary
- mask sensitive request fields before logging
- limit audit log metadata size
- catch audit log insert errors without blocking requests

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689a8b8f2f2c832191dc669410edb64e