### PR TITLE
Add environment variable validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 VITE_SUPABASE_URL=https://YOUR-REF.supabase.co
 VITE_SUPABASE_KEY=YOUR-ANON-KEY
 SUPABASE_DB_URL=postgresql://postgres:postgres@localhost:54322/postgres
+SUPABASE_URL=https://YOUR-REF.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=YOUR-SERVICE-ROLE-KEY
+SUPABASE_JWKS_URL=https://YOUR-REF.supabase.co/auth/v1/certs
+CORS_ORIGIN=http://localhost:3000

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -6,11 +6,12 @@ import { authMiddleware } from "./src/middleware/auth";
 import { auditLogger } from "./src/middleware/auditLogger";
 import modRoutes from "./src/routes/mod";
 import adminRoutes from "./src/routes/admin";
+import { env } from "./src/env";
 
 const app = express();
 app.use(express.json());
 app.use(helmet());
-app.use(cors({ origin: process.env.CORS_ORIGIN, credentials: true }));
+app.use(cors({ origin: env.CORS_ORIGIN, credentials: true }));
 app.use(rateLimit({ windowMs: 15 * 60 * 1000, max: 100 }));
 
 // Health check

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  SUPABASE_URL: z.string().url(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+  SUPABASE_JWKS_URL: z.string().url(),
+  CORS_ORIGIN: z.string().min(1),
+});
+
+const _env = envSchema.safeParse(process.env);
+
+if (!_env.success) {
+  console.error("Missing or invalid environment variables:");
+  console.error(_env.error.flatten().fieldErrors);
+  process.exit(1);
+}
+
+export const env = _env.data;

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -2,9 +2,10 @@ import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
 import jwksClient from "jwks-rsa";
 import { supabase } from "../utils/supabase";
+import { env } from "../env";
 
 const client = jwksClient({
-  jwksUri: process.env.SUPABASE_JWKS_URL!,
+  jwksUri: env.SUPABASE_JWKS_URL,
 });
 
 function getKey(header: any, callback: any) {

--- a/backend/src/utils/supabase.ts
+++ b/backend/src/utils/supabase.ts
@@ -1,7 +1,8 @@
 import { createClient } from "@supabase/supabase-js";
+import { env } from "../env";
 
 export const supabase = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  env.SUPABASE_URL,
+  env.SUPABASE_SERVICE_ROLE_KEY,
   { auth: { persistSession: false } }
 );


### PR DESCRIPTION
## Summary
- document backend env vars in .env.example
- validate required backend environment variables at startup
- use validated env vars in server, auth middleware, and Supabase client

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a903455bc8321b88a4406c3a6a6aa