### PR TITLE
Add backend tests and CI hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      - run: npm test
       - run: npm run -s build || true
       - run: npx supabase@latest db lint || true
       - run: npx supabase@latest db push --dry-run || true

--- a/backend/src/middleware/auditLogger.test.ts
+++ b/backend/src/middleware/auditLogger.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const { auditLogger } = await import('./auditLogger');
+const { supabase } = await import('../utils/supabase');
+
+test('redacts sensitive fields before logging', async (t) => {
+  const req: any = {
+    method: 'POST',
+    originalUrl: '/test',
+    body: { password: 'secret', token: 'abc', ok: 'yes' },
+    user: { id: '1' },
+  };
+  const res: any = {};
+  const next = t.mock.fn();
+
+  const insert = t.mock.fn(async () => ({}));
+  t.mock.method(supabase, 'from', () => ({ insert }));
+
+  await auditLogger(req, res, next);
+
+  assert.equal(insert.mock.callCount(), 1);
+  const arg = insert.mock.calls[0].arguments[0];
+  assert.deepEqual(arg, {
+    actor_id: '1',
+    action: 'POST /test',
+    metadata: { password: '[REDACTED]', token: '[REDACTED]', ok: 'yes' },
+  });
+  assert.equal(next.mock.callCount(), 1);
+});
+
+test('truncates large metadata', async (t) => {
+  const req: any = {
+    method: 'POST',
+    originalUrl: '/test',
+    body: { big: 'a'.repeat(1001) },
+    user: { id: '1' },
+  };
+  const res: any = {};
+  const next = t.mock.fn();
+
+  const insert = t.mock.fn(async () => ({}));
+  t.mock.method(supabase, 'from', () => ({ insert }));
+
+  await auditLogger(req, res, next);
+
+  const arg = insert.mock.calls[0].arguments[0];
+  assert.deepEqual(arg.metadata, { truncated: true });
+  assert.equal(next.mock.callCount(), 1);
+});

--- a/backend/src/middleware/auth.test.ts
+++ b/backend/src/middleware/auth.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import jwt from 'jsonwebtoken';
+
+process.env.SUPABASE_JWKS_URL = 'https://example.com';
+const { authMiddleware } = await import('./auth');
+const { supabase } = await import('../utils/supabase');
+
+test('returns 401 when Authorization header missing', async (t) => {
+  const req: any = { headers: {} };
+  const res: any = {
+    status: t.mock.fn().mockReturnThis(),
+    json: t.mock.fn(),
+  };
+  const next = t.mock.fn();
+
+  await authMiddleware(['admin'])(req, res, next);
+
+  assert.equal(res.status.mock.calls[0].arguments[0], 401);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('returns 401 on invalid token', async (t) => {
+  const req: any = { headers: { authorization: 'Bearer bad' } };
+  const res: any = {
+    status: t.mock.fn().mockReturnThis(),
+    json: t.mock.fn(),
+  };
+  const next = t.mock.fn();
+
+  t.mock.method(jwt, 'verify', (_t, _k, _o, cb) => cb(new Error('bad token'), null));
+
+  await authMiddleware(['admin'])(req, res, next);
+
+  assert.equal(res.status.mock.calls[0].arguments[0], 401);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('returns 403 when user role not allowed', async (t) => {
+  const req: any = { headers: { authorization: 'Bearer good' } };
+  const res: any = {
+    status: t.mock.fn().mockReturnThis(),
+    json: t.mock.fn(),
+  };
+  const next = t.mock.fn();
+
+  t.mock.method(jwt, 'verify', (_t, _k, _o, cb) => cb(null, { sub: 'user1' }));
+  t.mock.method(supabase, 'from', () => ({
+    select: () => ({
+      eq: () => ({
+        single: async () => ({ data: { id: 'user1', role: 'user' } }),
+      }),
+    }),
+  }));
+
+  await authMiddleware(['admin'])(req, res, next);
+  await new Promise(process.nextTick);
+
+  assert.equal(res.status.mock.calls[0].arguments[0], 403);
+  assert.equal(next.mock.callCount(), 0);
+});
+
+test('calls next for allowed role', async (t) => {
+  const req: any = { headers: { authorization: 'Bearer good' } };
+  const res: any = {
+    status: t.mock.fn().mockReturnThis(),
+    json: t.mock.fn(),
+  };
+  const next = t.mock.fn();
+
+  t.mock.method(jwt, 'verify', (_t, _k, _o, cb) => cb(null, { sub: 'user1' }));
+  t.mock.method(supabase, 'from', () => ({
+    select: () => ({
+      eq: () => ({
+        single: async () => ({ data: { id: 'user1', role: 'admin' } }),
+      }),
+    }),
+  }));
+
+  await authMiddleware(['admin'])(req, res, next);
+  await new Promise(process.nextTick);
+
+  assert.equal(next.mock.callCount(), 1);
+  assert.deepEqual(req.user, { id: 'user1', role: 'admin' });
+});

--- a/backend/src/routes/admin.test.ts
+++ b/backend/src/routes/admin.test.ts
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+const { supabase } = await import('../utils/supabase');
+import adminRoutes from './admin';
+
+test('approves a ban', async (t) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/admin', adminRoutes);
+
+  const id = '123e4567-e89b-12d3-a456-426614174000';
+
+  const eq = t.mock.fn(async () => ({ data: [{ id, status: 'approved' }], error: null }));
+  const update = t.mock.fn(() => ({ eq }));
+  t.mock.method(supabase, 'from', () => ({ update }));
+
+  const server = app.listen(0);
+  t.teardown(() => server.close());
+  await new Promise((resolve) => server.once('listening', resolve));
+  const port = (server.address() as any).port;
+
+  const res = await fetch(`http://127.0.0.1:${port}/admin/bans/${id}/approve`, {
+    method: 'PATCH',
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(eq.mock.calls[0].arguments[0], 'id');
+  assert.equal(eq.mock.calls[0].arguments[1], id);
+  assert.equal(update.mock.calls[0].arguments[0].status, 'approved');
+  assert.equal(body[0].status, 'approved');
+});

--- a/backend/src/routes/mod.test.ts
+++ b/backend/src/routes/mod.test.ts
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+const { supabase } = await import('../utils/supabase');
+import modRoutes from './mod';
+
+test('creates a ban request', async (t) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/mod', modRoutes);
+
+  const insert = t.mock.fn(async () => ({ data: [{ id: 'ban1' }], error: null }));
+  t.mock.method(supabase, 'from', () => ({ insert }));
+
+  const server = app.listen(0);
+  t.teardown(() => server.close());
+  await new Promise((resolve) => server.once('listening', resolve));
+  const port = (server.address() as any).port;
+
+  const body = {
+    target_id: '123e4567-e89b-12d3-a456-426614174000',
+    reason: 'spam',
+  };
+  const res = await fetch(`http://127.0.0.1:${port}/mod/bans`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(insert.mock.calls[0].arguments[0], {
+    ...body,
+    status: 'pending',
+  });
+});
+
+test('returns 400 on invalid body', async (t) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/mod', modRoutes);
+  const server = app.listen(0);
+  t.teardown(() => server.close());
+  await new Promise((resolve) => server.once('listening', resolve));
+  const port = (server.address() as any).port;
+
+  const res = await fetch(`http://127.0.0.1:${port}/mod/bans`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+
+  assert.equal(res.status, 400);
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "preview": "vite preview",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "test": "node --import tsx --test server/**/*.test.ts",
+    "test": "node --import tsx --test $(find backend server -name '*.test.ts')",
     "db:reset": "supabase db reset",
     "db:push": "supabase db push",
     "db:push:drizzle": "drizzle-kit push",


### PR DESCRIPTION
## Summary
- add Node test runner for backend middleware and routes
- test auth middleware, admin/mod endpoints, and audit logger
- run test suite in CI

## Testing
- `npm test` *(fails: Cannot find package '@supabase/supabase-js')*


------
https://chatgpt.com/codex/tasks/task_e_689a903a2e008321a0aeca5705362c85