### PR TITLE
Implement simple API key auth middleware

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -2,7 +2,7 @@ import express from "express";
 import helmet from "helmet";
 import cors from "cors";
 import rateLimit from "express-rate-limit";
-import { authMiddleware } from "./src/middleware/auth";
+import { simpleAuth } from "./src/middleware/auth";
 import { auditLogger } from "./src/middleware/auditLogger";
 import modRoutes from "./src/routes/mod";
 import adminRoutes from "./src/routes/admin";
@@ -18,8 +18,8 @@ app.use(rateLimit({ windowMs: 15 * 60 * 1000, max: 100 }));
 app.get("/health", (_req, res) => res.json({ status: "ok" }));
 
 // Protected routes
-app.use("/mod", authMiddleware(["moderator", "admin"]), auditLogger, modRoutes);
-app.use("/admin", authMiddleware(["admin"]), auditLogger, adminRoutes);
+app.use("/mod", simpleAuth(["moderator", "admin"]), auditLogger, modRoutes);
+app.use("/admin", simpleAuth(["admin"]), auditLogger, adminRoutes);
 
 const port = process.env.PORT || 4000;
 app.listen(port, () => {

--- a/backend/src/middleware/auditLogger.test.ts
+++ b/backend/src/middleware/auditLogger.test.ts
@@ -1,6 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'service';
+process.env.SUPABASE_JWKS_URL = 'http://localhost/jwks';
+process.env.CORS_ORIGIN = '*';
+
 const { auditLogger } = await import('./auditLogger');
 const { supabase } = await import('../utils/supabase');
 

--- a/backend/src/middleware/auth.test.ts
+++ b/backend/src/middleware/auth.test.ts
@@ -1,85 +1,56 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import jwt from 'jsonwebtoken';
 
-process.env.SUPABASE_JWKS_URL = 'https://example.com';
-const { authMiddleware } = await import('./auth');
-const { supabase } = await import('../utils/supabase');
+process.env.API_KEY = 'secret';
+const { simpleAuth } = await import('./auth');
 
-test('returns 401 when Authorization header missing', async (t) => {
+function createRes(t: any) {
+  const res: any = {};
+  res.status = t.mock.fn(() => res);
+  res.json = t.mock.fn();
+  return res;
+}
+
+test('returns 401 when API key missing', async (t) => {
   const req: any = { headers: {} };
-  const res: any = {
-    status: t.mock.fn().mockReturnThis(),
-    json: t.mock.fn(),
-  };
+  const res = createRes(t);
   const next = t.mock.fn();
 
-  await authMiddleware(['admin'])(req, res, next);
+  await simpleAuth(['admin'])(req, res as any, next);
 
   assert.equal(res.status.mock.calls[0].arguments[0], 401);
   assert.equal(next.mock.callCount(), 0);
 });
 
-test('returns 401 on invalid token', async (t) => {
-  const req: any = { headers: { authorization: 'Bearer bad' } };
-  const res: any = {
-    status: t.mock.fn().mockReturnThis(),
-    json: t.mock.fn(),
-  };
+test('returns 401 when API key invalid', async (t) => {
+  const req: any = { headers: { 'x-api-key': 'bad' } };
+  const res = createRes(t);
   const next = t.mock.fn();
 
-  t.mock.method(jwt, 'verify', (_t, _k, _o, cb) => cb(new Error('bad token'), null));
-
-  await authMiddleware(['admin'])(req, res, next);
+  await simpleAuth(['admin'])(req, res as any, next);
 
   assert.equal(res.status.mock.calls[0].arguments[0], 401);
   assert.equal(next.mock.callCount(), 0);
 });
 
-test('returns 403 when user role not allowed', async (t) => {
-  const req: any = { headers: { authorization: 'Bearer good' } };
-  const res: any = {
-    status: t.mock.fn().mockReturnThis(),
-    json: t.mock.fn(),
-  };
+test('returns 403 when role not allowed', async (t) => {
+  const req: any = { headers: { 'x-api-key': 'secret' } };
+  const res = createRes(t);
   const next = t.mock.fn();
 
-  t.mock.method(jwt, 'verify', (_t, _k, _o, cb) => cb(null, { sub: 'user1' }));
-  t.mock.method(supabase, 'from', () => ({
-    select: () => ({
-      eq: () => ({
-        single: async () => ({ data: { id: 'user1', role: 'user' } }),
-      }),
-    }),
-  }));
-
-  await authMiddleware(['admin'])(req, res, next);
-  await new Promise(process.nextTick);
+  await simpleAuth(['user'])(req, res as any, next);
 
   assert.equal(res.status.mock.calls[0].arguments[0], 403);
   assert.equal(next.mock.callCount(), 0);
 });
 
-test('calls next for allowed role', async (t) => {
-  const req: any = { headers: { authorization: 'Bearer good' } };
-  const res: any = {
-    status: t.mock.fn().mockReturnThis(),
-    json: t.mock.fn(),
-  };
+test('calls next for allowed role and attaches user', async (t) => {
+  const req: any = { headers: { 'x-api-key': 'secret' } };
+  const res = createRes(t);
   const next = t.mock.fn();
 
-  t.mock.method(jwt, 'verify', (_t, _k, _o, cb) => cb(null, { sub: 'user1' }));
-  t.mock.method(supabase, 'from', () => ({
-    select: () => ({
-      eq: () => ({
-        single: async () => ({ data: { id: 'user1', role: 'admin' } }),
-      }),
-    }),
-  }));
-
-  await authMiddleware(['admin'])(req, res, next);
-  await new Promise(process.nextTick);
+  await simpleAuth(['admin'])(req, res as any, next);
 
   assert.equal(next.mock.callCount(), 1);
-  assert.deepEqual(req.user, { id: 'user1', role: 'admin' });
+  assert.deepEqual(req.user, { id: 'secret', role: 'admin' });
 });

--- a/backend/src/routes/mod.test.ts
+++ b/backend/src/routes/mod.test.ts
@@ -1,8 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import express from 'express';
+
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'service';
+process.env.SUPABASE_JWKS_URL = 'http://localhost/jwks';
+process.env.CORS_ORIGIN = '*';
+
 const { supabase } = await import('../utils/supabase');
-import modRoutes from './mod';
+const { default: modRoutes } = await import('./mod');
 
 test('creates a ban request', async (t) => {
   const app = express();
@@ -13,7 +19,6 @@ test('creates a ban request', async (t) => {
   t.mock.method(supabase, 'from', () => ({ insert }));
 
   const server = app.listen(0);
-  t.teardown(() => server.close());
   await new Promise((resolve) => server.once('listening', resolve));
   const port = (server.address() as any).port;
 
@@ -21,17 +26,21 @@ test('creates a ban request', async (t) => {
     target_id: '123e4567-e89b-12d3-a456-426614174000',
     reason: 'spam',
   };
-  const res = await fetch(`http://127.0.0.1:${port}/mod/bans`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/mod/bans`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
 
-  assert.equal(res.status, 200);
-  assert.deepEqual(insert.mock.calls[0].arguments[0], {
-    ...body,
-    status: 'pending',
-  });
+    assert.equal(res.status, 200);
+    assert.deepEqual(insert.mock.calls[0].arguments[0], {
+      ...body,
+      status: 'pending',
+    });
+  } finally {
+    server.close();
+  }
 });
 
 test('returns 400 on invalid body', async (t) => {
@@ -39,15 +48,18 @@ test('returns 400 on invalid body', async (t) => {
   app.use(express.json());
   app.use('/mod', modRoutes);
   const server = app.listen(0);
-  t.teardown(() => server.close());
   await new Promise((resolve) => server.once('listening', resolve));
   const port = (server.address() as any).port;
 
-  const res = await fetch(`http://127.0.0.1:${port}/mod/bans`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({}),
-  });
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/mod/bans`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
 
-  assert.equal(res.status, 400);
+    assert.equal(res.status, 400);
+  } finally {
+    server.close();
+  }
 });


### PR DESCRIPTION
## Summary
- replace JWT auth with simple API key role check
- wire `simpleAuth` into server routes
- adjust tests to use API keys and provide env vars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a9a50cfd483219b25391bf0f7579d