### PR TITLE
refactor routes to use in-memory store

### DIFF
--- a/backend/src/routes/admin.test.ts
+++ b/backend/src/routes/admin.test.ts
@@ -1,24 +1,28 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import express from 'express';
-const { supabase } = await import('../utils/supabase');
 import adminRoutes from './admin';
+import { bans, threads } from '../store';
 
-test('approves a ban', async (t) => {
+async function setupApp(t: test.TestContext) {
   const app = express();
   app.use(express.json());
   app.use('/admin', adminRoutes);
-
-  const id = '123e4567-e89b-12d3-a456-426614174000';
-
-  const eq = t.mock.fn(async () => ({ data: [{ id, status: 'approved' }], error: null }));
-  const update = t.mock.fn(() => ({ eq }));
-  t.mock.method(supabase, 'from', () => ({ update }));
-
   const server = app.listen(0);
-  t.teardown(() => server.close());
+  t.after(() => server.close());
   await new Promise((resolve) => server.once('listening', resolve));
   const port = (server.address() as any).port;
+  return { app, port };
+}
+
+test('approves a ban', async (t) => {
+  const { port } = await setupApp(t);
+  const id = '00000000-0000-0000-0000-000000000001';
+  bans.push({ id, status: 'pending' });
+  t.after(() => {
+    const i = bans.findIndex((b) => b.id === id);
+    if (i !== -1) bans.splice(i, 1);
+  });
 
   const res = await fetch(`http://127.0.0.1:${port}/admin/bans/${id}/approve`, {
     method: 'PATCH',
@@ -26,8 +30,44 @@ test('approves a ban', async (t) => {
   const body = await res.json();
 
   assert.equal(res.status, 200);
-  assert.equal(eq.mock.calls[0].arguments[0], 'id');
-  assert.equal(eq.mock.calls[0].arguments[1], id);
-  assert.equal(update.mock.calls[0].arguments[0].status, 'approved');
   assert.equal(body[0].status, 'approved');
+  assert.equal(bans.find((b) => b.id === id)?.status, 'approved');
+});
+
+test('lifts a ban', async (t) => {
+  const { port } = await setupApp(t);
+  const id = '00000000-0000-0000-0000-000000000002';
+  bans.push({ id, status: 'approved' });
+  t.after(() => {
+    const i = bans.findIndex((b) => b.id === id);
+    if (i !== -1) bans.splice(i, 1);
+  });
+
+  const res = await fetch(`http://127.0.0.1:${port}/admin/bans/${id}/lift`, {
+    method: 'PATCH',
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body[0].status, 'lifted');
+  assert.equal(bans.find((b) => b.id === id)?.status, 'lifted');
+});
+
+test('restores a thread', async (t) => {
+  const { port } = await setupApp(t);
+  const id = '00000000-0000-0000-0000-000000000003';
+  threads.push({ id, deleted: true });
+  t.after(() => {
+    const i = threads.findIndex((th) => th.id === id);
+    if (i !== -1) threads.splice(i, 1);
+  });
+
+  const res = await fetch(`http://127.0.0.1:${port}/admin/threads/${id}/restore`, {
+    method: 'PATCH',
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body[0].deleted, false);
+  assert.equal(threads.find((th) => th.id === id)?.deleted, false);
 });

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,51 +1,45 @@
 import { Router } from "express";
 import { z } from "zod";
-import { supabase } from "../utils/supabase";
+import { bans, threads } from "../store";
 
 const router = Router();
 
 const idSchema = z.object({ id: z.string().uuid() });
 
-router.patch("/bans/:id/approve", async (req, res) => {
+router.patch("/bans/:id/approve", (req, res) => {
   const result = idSchema.safeParse(req.params);
   if (!result.success) {
     return res.status(400).json({ error: result.error.flatten() });
   }
   const { id } = result.data;
-  const { data, error } = await supabase
-    .from("bans")
-    .update({ status: "approved" })
-    .eq("id", id);
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(data);
+  const ban = bans.find((b) => b.id === id);
+  if (!ban) return res.status(404).json({ error: "Ban not found" });
+  ban.status = "approved";
+  res.json([ban]);
 });
 
-router.patch("/bans/:id/lift", async (req, res) => {
+router.patch("/bans/:id/lift", (req, res) => {
   const result = idSchema.safeParse(req.params);
   if (!result.success) {
     return res.status(400).json({ error: result.error.flatten() });
   }
   const { id } = result.data;
-  const { data, error } = await supabase
-    .from("bans")
-    .update({ status: "lifted" })
-    .eq("id", id);
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(data);
+  const ban = bans.find((b) => b.id === id);
+  if (!ban) return res.status(404).json({ error: "Ban not found" });
+  ban.status = "lifted";
+  res.json([ban]);
 });
 
-router.patch("/threads/:id/restore", async (req, res) => {
+router.patch("/threads/:id/restore", (req, res) => {
   const result = idSchema.safeParse(req.params);
   if (!result.success) {
     return res.status(400).json({ error: result.error.flatten() });
   }
   const { id } = result.data;
-  const { data, error } = await supabase
-    .from("threads")
-    .update({ deleted: false })
-    .eq("id", id);
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(data);
+  const thread = threads.find((t) => t.id === id);
+  if (!thread) return res.status(404).json({ error: "Thread not found" });
+  thread.deleted = false;
+  res.json([thread]);
 });
 
 export default router;

--- a/backend/src/routes/mod.test.ts
+++ b/backend/src/routes/mod.test.ts
@@ -1,24 +1,24 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import express from 'express';
-const { supabase } = await import('../utils/supabase');
 import modRoutes from './mod';
+import { bans, posts } from '../store';
 
-test('creates a ban request', async (t) => {
+async function setupApp(t: test.TestContext) {
   const app = express();
   app.use(express.json());
   app.use('/mod', modRoutes);
-
-  const insert = t.mock.fn(async () => ({ data: [{ id: 'ban1' }], error: null }));
-  t.mock.method(supabase, 'from', () => ({ insert }));
-
   const server = app.listen(0);
-  t.teardown(() => server.close());
+  t.after(() => server.close());
   await new Promise((resolve) => server.once('listening', resolve));
   const port = (server.address() as any).port;
+  return { app, port };
+}
 
+test('creates a ban request', async (t) => {
+  const { port } = await setupApp(t);
   const body = {
-    target_id: '123e4567-e89b-12d3-a456-426614174000',
+    target_id: '00000000-0000-0000-0000-000000000004',
     reason: 'spam',
   };
   const res = await fetch(`http://127.0.0.1:${port}/mod/bans`, {
@@ -26,28 +26,43 @@ test('creates a ban request', async (t) => {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+  const data = await res.json();
+  const id = data[0].id;
+  t.after(() => {
+    const i = bans.findIndex((b) => b.id === id);
+    if (i !== -1) bans.splice(i, 1);
+  });
 
   assert.equal(res.status, 200);
-  assert.deepEqual(insert.mock.calls[0].arguments[0], {
-    ...body,
-    status: 'pending',
-  });
+  assert.equal(bans.find((b) => b.id === id)?.status, 'pending');
+  assert.equal(bans.find((b) => b.id === id)?.target_id, body.target_id);
 });
 
 test('returns 400 on invalid body', async (t) => {
-  const app = express();
-  app.use(express.json());
-  app.use('/mod', modRoutes);
-  const server = app.listen(0);
-  t.teardown(() => server.close());
-  await new Promise((resolve) => server.once('listening', resolve));
-  const port = (server.address() as any).port;
-
+  const { port } = await setupApp(t);
   const res = await fetch(`http://127.0.0.1:${port}/mod/bans`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({}),
   });
-
   assert.equal(res.status, 400);
+});
+
+test('soft deletes a post', async (t) => {
+  const { port } = await setupApp(t);
+  const id = '00000000-0000-0000-0000-000000000005';
+  posts.push({ id, deleted: false });
+  t.after(() => {
+    const i = posts.findIndex((p) => p.id === id);
+    if (i !== -1) posts.splice(i, 1);
+  });
+
+  const res = await fetch(`http://127.0.0.1:${port}/mod/posts/${id}/soft-delete`, {
+    method: 'PATCH',
+  });
+  const body = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(body[0].deleted, true);
+  assert.equal(posts.find((p) => p.id === id)?.deleted, true);
 });

--- a/backend/src/routes/mod.test.ts
+++ b/backend/src/routes/mod.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import express from 'express';
 import modRoutes from './mod';
-import { bans, posts } from '../store';
+import { bans, posts, flags } from '../store';
 
 async function setupApp(t: test.TestContext) {
   const app = express();
@@ -36,6 +36,22 @@ test('creates a ban request', async (t) => {
   assert.equal(res.status, 200);
   assert.equal(bans.find((b) => b.id === id)?.status, 'pending');
   assert.equal(bans.find((b) => b.id === id)?.target_id, body.target_id);
+});
+
+test('returns flags', async (t) => {
+  const { port } = await setupApp(t);
+  const id = '00000000-0000-0000-0000-000000000006';
+  flags.push({ id });
+  t.after(() => {
+    const i = flags.findIndex((f) => f.id === id);
+    if (i !== -1) flags.splice(i, 1);
+  });
+
+  const res = await fetch(`http://127.0.0.1:${port}/mod/flags`);
+  const data = await res.json();
+
+  assert.equal(res.status, 200);
+  assert.equal(data.find((f: any) => f.id === id)?.id, id);
 });
 
 test('returns 400 on invalid body', async (t) => {

--- a/backend/src/routes/mod.ts
+++ b/backend/src/routes/mod.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
-import { supabase } from "../utils/supabase";
+import { randomUUID } from "node:crypto";
+import { bans, posts, flags } from "../store";
 
 const router = Router();
 
@@ -10,37 +11,31 @@ const banSchema = z.object({
   reason: z.string().min(1),
 });
 
-router.get("/flags", async (_req, res) => {
-  const { data, error } = await supabase.from("flags").select("*");
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(data);
+router.get("/flags", (_req, res) => {
+  res.json(flags);
 });
 
-router.patch("/posts/:id/soft-delete", async (req, res) => {
+router.patch("/posts/:id/soft-delete", (req, res) => {
   const result = idSchema.safeParse(req.params);
   if (!result.success) {
     return res.status(400).json({ error: result.error.flatten() });
   }
   const { id } = result.data;
-  const { data, error } = await supabase
-    .from("posts")
-    .update({ deleted: true })
-    .eq("id", id);
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(data);
+  const post = posts.find((p) => p.id === id);
+  if (!post) return res.status(404).json({ error: "Post not found" });
+  post.deleted = true;
+  res.json([post]);
 });
 
-router.post("/bans", async (req, res) => {
+router.post("/bans", (req, res) => {
   const result = banSchema.safeParse(req.body);
   if (!result.success) {
     return res.status(400).json({ error: result.error.flatten() });
   }
   const { target_id, reason } = result.data;
-  const { data, error } = await supabase
-    .from("bans")
-    .insert({ target_id, reason, status: "pending" });
-  if (error) return res.status(500).json({ error: error.message });
-  res.json(data);
+  const ban = { id: randomUUID(), target_id, reason, status: "pending" };
+  bans.push(ban);
+  res.json([ban]);
 });
 
 export default router;

--- a/backend/src/store.ts
+++ b/backend/src/store.ts
@@ -1,0 +1,9 @@
+export interface Post { id: string; deleted?: boolean }
+export interface Ban { id: string; target_id?: string; reason?: string; status: string }
+export interface Flag { id: string }
+export interface Thread { id: string; deleted?: boolean }
+
+export const posts: Post[] = [];
+export const bans: Ban[] = [];
+export const flags: Flag[] = [];
+export const threads: Thread[] = [];


### PR DESCRIPTION
## Summary
- replace Supabase calls with in-memory arrays for moderation and admin routes
- add backend/src/store.ts to hold posts, bans, flags, and threads
- update route tests to use the in-memory store

## Testing
- `node --import tsx --test backend/src/routes/admin.test.ts backend/src/routes/mod.test.ts`
- `npm test` *(fails: Cannot find package 'jsonwebtoken')*

------
https://chatgpt.com/codex/tasks/task_e_689aa1b73d4c83219dbaf89f2771ed02