### PR TITLE
docs: note htaccess usage for admin/mod routes

### DIFF
--- a/backend/src/routes/admin.test.ts
+++ b/backend/src/routes/admin.test.ts
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import adminRouter from './admin';
+import { randomUUID } from 'node:crypto';
+
+function buildServer() {
+  const app = express();
+  app.use(express.json());
+  app.use(adminRouter);
+  const server = app.listen(0);
+  const { port } = server.address() as any;
+  return { server, port };
+}
+
+test('approves a ban with valid id', async () => {
+  const { server, port } = buildServer();
+  const id = randomUUID();
+  try {
+    const res = await fetch(`http://localhost:${port}/bans/${id}/approve`, { method: 'PATCH' });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, [{ id, status: 'approved' }]);
+  } finally {
+    server.close();
+  }
+});
+
+test('rejects invalid ban id', async () => {
+  const { server, port } = buildServer();
+  try {
+    const res = await fetch(`http://localhost:${port}/bans/not-a-uuid/approve`, { method: 'PATCH' });
+    assert.equal(res.status, 400);
+  } finally {
+    server.close();
+  }
+});
+
+test('restores thread', async () => {
+  const { server, port } = buildServer();
+  const id = randomUUID();
+  try {
+    const res = await fetch(`http://localhost:${port}/threads/${id}/restore`, { method: 'PATCH' });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, [{ id, deleted: false }]);
+  } finally {
+    server.close();
+  }
+});

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { z } from "zod";
 
+// Access to these routes is expected to be restricted via `.htaccess`.
+// Supabase is not used for authentication here.
 const router = Router();
 
 const idSchema = z.object({ id: z.string().uuid() });

--- a/backend/src/routes/mod.test.ts
+++ b/backend/src/routes/mod.test.ts
@@ -1,0 +1,70 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import modRouter from './mod';
+import { randomUUID } from 'node:crypto';
+
+function buildServer() {
+  const app = express();
+  app.use(express.json());
+  app.use(modRouter);
+  const server = app.listen(0);
+  const { port } = server.address() as any;
+  return { server, port };
+}
+
+test('lists flags', async () => {
+  const { server, port } = buildServer();
+  try {
+    const res = await fetch(`http://localhost:${port}/flags`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, []);
+  } finally {
+    server.close();
+  }
+});
+
+test('soft deletes a post', async () => {
+  const { server, port } = buildServer();
+  const id = randomUUID();
+  try {
+    const res = await fetch(`http://localhost:${port}/posts/${id}/soft-delete`, { method: 'PATCH' });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, [{ id, deleted: true }]);
+  } finally {
+    server.close();
+  }
+});
+
+test('creates a ban', async () => {
+  const { server, port } = buildServer();
+  const target_id = randomUUID();
+  try {
+    const res = await fetch(`http://localhost:${port}/bans`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ target_id, reason: 'spam' }),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, [{ id: 'ban1', target_id, reason: 'spam', status: 'pending' }]);
+  } finally {
+    server.close();
+  }
+});
+
+test('rejects invalid ban body', async () => {
+  const { server, port } = buildServer();
+  try {
+    const res = await fetch(`http://localhost:${port}/bans`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ target_id: 'not-a-uuid', reason: '' }),
+    });
+    assert.equal(res.status, 400);
+  } finally {
+    server.close();
+  }
+});

--- a/backend/src/routes/mod.ts
+++ b/backend/src/routes/mod.ts
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { z } from "zod";
 
+// Access to these routes is expected to be restricted via `.htaccess`.
+// Supabase is not used for authentication here.
 const router = Router();
 
 const idSchema = z.object({ id: z.string().uuid() });


### PR DESCRIPTION
## Summary
- clarify that admin and mod routes are protected via `.htaccess` and not Supabase
- add route tests for admin and mod endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689aa7ba5dfc8321b932a3ad85696fcd