### PR TITLE
Add htpasswd user management endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ SUPABASE_URL=https://YOUR-REF.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=YOUR-SERVICE-ROLE-KEY
 SUPABASE_JWKS_URL=https://YOUR-REF.supabase.co/auth/v1/certs
 CORS_ORIGIN=http://localhost:3000
+HTPASSWD_PATH=.htpasswd

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -1,4 +1,5 @@
 export const env = {
   API_KEY: process.env.API_KEY || "dev-key",
-  PORT: Number(process.env.PORT || 4000)
+  PORT: Number(process.env.PORT || 4000),
+  HTPASSWD_PATH: process.env.HTPASSWD_PATH || ".htpasswd"
 };

--- a/backend/src/routes/admin.test.ts
+++ b/backend/src/routes/admin.test.ts
@@ -2,7 +2,11 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import express from 'express';
 import adminRouter from './admin';
-import { randomUUID } from 'node:crypto';
+import { randomUUID, createHash } from 'node:crypto';
+import { env } from '../env';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 function buildServer() {
   const app = express();
@@ -44,6 +48,71 @@ test('restores thread', async () => {
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.deepEqual(body, [{ id, deleted: false }]);
+  } finally {
+    server.close();
+  }
+});
+
+test('adds htaccess user', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'htpasswd-'));
+  const file = path.join(dir, '.htpasswd');
+  env.HTPASSWD_PATH = file;
+  const { server, port } = buildServer();
+  try {
+    const res = await fetch(`http://localhost:${port}/htaccess/users`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'alice', password: 'secret' })
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, { success: true });
+    const contents = await fs.readFile(file, 'utf8');
+    const [user, hash] = contents.trim().split(':');
+    assert.equal(user, 'alice');
+    const expected = '{SHA}' + createHash('sha1').update('secret').digest('base64');
+    assert.equal(hash, expected);
+  } finally {
+    server.close();
+  }
+});
+
+test('rejects invalid htaccess input', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'htpasswd-'));
+  const file = path.join(dir, '.htpasswd');
+  env.HTPASSWD_PATH = file;
+  const { server, port } = buildServer();
+  try {
+    const res = await fetch(`http://localhost:${port}/htaccess/users`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 123 })
+    });
+    assert.equal(res.status, 400);
+  } finally {
+    server.close();
+  }
+});
+
+test('appends to htpasswd file', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'htpasswd-'));
+  const file = path.join(dir, '.htpasswd');
+  env.HTPASSWD_PATH = file;
+  const { server, port } = buildServer();
+  try {
+    await fetch(`http://localhost:${port}/htaccess/users`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'user1', password: 'pass1' })
+    });
+    await fetch(`http://localhost:${port}/htaccess/users`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'user2', password: 'pass2' })
+    });
+    const contents = await fs.readFile(file, 'utf8');
+    const lines = contents.trim().split('\n');
+    assert.equal(lines.length, 2);
   } finally {
     server.close();
   }

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,11 +1,15 @@
 import { Router } from "express";
 import { z } from "zod";
+import fs from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { env } from "../env";
 
 // Access to these routes is expected to be restricted via `.htaccess`.
 // Supabase is not used for authentication here.
 const router = Router();
 
 const idSchema = z.object({ id: z.string().uuid() });
+const htUserSchema = z.object({ username: z.string(), password: z.string() });
 
 router.patch("/bans/:id/approve", (req, res) => {
   const result = idSchema.safeParse(req.params);
@@ -32,6 +36,21 @@ router.patch("/threads/:id/restore", (req, res) => {
   }
   const { id } = result.data;
   res.json([{ id, deleted: false }]);
+});
+
+router.post("/htaccess/users", async (req, res) => {
+  const result = htUserSchema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json({ error: result.error.flatten() });
+  }
+  const { username, password } = result.data;
+  try {
+    const digest = createHash("sha1").update(password).digest("base64");
+    await fs.appendFile(env.HTPASSWD_PATH, `${username}:{SHA}${digest}\n`);
+    res.json({ success: true });
+  } catch (error) {
+    res.status(500).json({ error: "Failed to update htpasswd" });
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- add POST /htaccess/users route to manage htpasswd entries
- validate body with zod and hash password with SHA1
- add tests for valid/invalid input and file append behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689aab0191f483218b0761f13efbc5ef