### PR TITLE
feat: enforce role-based auth

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -6,6 +6,11 @@ import adminRoutes from "./src/routes/admin";
 
 const app = express();
 app.use(express.json());
-app.use("/mod", authMiddleware(["moderator", "admin"]), modRoutes);
-app.use("/admin", authMiddleware(["admin"]), adminRoutes);
+
+const modRoles = ["moderator", "admin"];
+const adminRoles = ["admin"];
+
+app.use("/mod", authMiddleware(modRoles), modRoutes);
+app.use("/admin", authMiddleware(adminRoles), adminRoutes);
+
 app.listen(env.PORT);

--- a/backend/src/middleware/auth.test.ts
+++ b/backend/src/middleware/auth.test.ts
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import { authMiddleware } from './auth';
+import { env } from '../env';
+
+function buildServer(allowedRoles: string[]) {
+  const app = express();
+  app.use(authMiddleware(allowedRoles));
+  app.get('/protected', (_req, res) => {
+    res.json({ ok: true });
+  });
+  const server = app.listen(0);
+  const { port } = server.address() as any;
+  return { server, port };
+}
+
+test('rejects request with unauthorized roles', async () => {
+  const { server, port } = buildServer(['admin']);
+  try {
+    const res = await fetch(`http://localhost:${port}/protected`, {
+      headers: {
+        'x-api-key': env.API_KEY,
+        'x-roles': 'user'
+      }
+    });
+    assert.equal(res.status, 401);
+  } finally {
+    server.close();
+  }
+});
+
+test('allows request with matching role', async () => {
+  const { server, port } = buildServer(['admin']);
+  try {
+    const res = await fetch(`http://localhost:${port}/protected`, {
+      headers: {
+        'x-api-key': env.API_KEY,
+        'x-roles': 'user,admin'
+      }
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, { ok: true });
+  } finally {
+    server.close();
+  }
+});

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,10 +1,18 @@
 import { Request, Response, NextFunction } from "express";
 import { env } from "../env";
 
-export function authMiddleware(_allowedRoles: string[]) {
+export function authMiddleware(allowedRoles: string[]) {
   return (req: Request, res: Response, next: NextFunction) => {
     const apiKey = req.header("x-api-key");
     if (apiKey !== env.API_KEY) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+    const rolesHeader = req.header("x-roles") ?? "";
+    const roles = rolesHeader
+      .split(",")
+      .map((r) => r.trim())
+      .filter(Boolean);
+    if (allowedRoles.length && !roles.some((r) => allowedRoles.includes(r))) {
       return res.status(401).json({ error: "Unauthorized" });
     }
     next();


### PR DESCRIPTION
## Summary
- parse comma-separated roles from `X-Roles` header and verify at least one matches allowed roles
- define role arrays for mod and admin routes when attaching auth middleware
- add tests covering unauthorized role rejection and authorized access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689aab06cc348321a7b3453f978321d6