### PR TITLE
Document API key auth for moderation routes

### DIFF
--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
 
-// Access to these routes is expected to be restricted via `.htaccess`.
+// Access to these routes is restricted via an API key in the `x-api-key` header.
 // Supabase is not used for authentication here.
 const router = Router();
 

--- a/backend/src/routes/mod.ts
+++ b/backend/src/routes/mod.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
 
-// Access to these routes is expected to be restricted via `.htaccess`.
+// Access to these routes is restricted via an API key in the `x-api-key` header.
 // Supabase is not used for authentication here.
 const router = Router();
 

--- a/docs/Backend.md
+++ b/docs/Backend.md
@@ -7,9 +7,21 @@
 - Role-based auth for moderators and admins
 - Audit logging for all mod/admin actions
 - Soft delete + ban approval workflow
+- API key authentication for mod and admin routes
 
 ## Setup
 1. Copy `.env.example` → `.env` and fill with your Supabase project details.
-2. Install dependencies:
+2. Set `API_KEY` in `.env` to the value clients must send.
+3. Install dependencies:
    ```bash
    npm install
+   ```
+4. Start the server:
+   ```bash
+   npm run dev:server
+   ```
+
+## Authentication
+
+Requests to the `/mod` and `/admin` routes must include the API key via the `x-api-key` header. Supabase is not used for this authentication flow.
+


### PR DESCRIPTION
## Summary
- clarify that mod and admin routes are protected by an API key
- remove `.htaccess` references from code comments
- document API key authentication in backend docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689aab07f7fc832187c9251bf612d748