### PR TITLE
feat: add htaccess admin page

### DIFF
--- a/client/src/pages/htaccess-admin.tsx
+++ b/client/src/pages/htaccess-admin.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+const formSchema = z.object({
+  username: z.string().min(1, "Username is required"),
+  password: z.string().min(1, "Password is required"),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+export default function HtaccessAdmin() {
+  const [users, setUsers] = useState<{ username: string }[]>([]);
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { username: "", password: "" },
+  });
+
+  const loadUsers = async () => {
+    const res = await fetch("/admin/htaccess/users");
+    if (res.ok) {
+      const data = await res.json();
+      setUsers(data);
+    }
+  };
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  const onSubmit = async (values: FormValues) => {
+    await fetch("/admin/htaccess/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(values),
+    });
+    form.reset();
+    loadUsers();
+  };
+
+  const removeUser = async (username: string) => {
+    await fetch(`/admin/htaccess/users/${encodeURIComponent(username)}`, {
+      method: "DELETE",
+    });
+    loadUsers();
+  };
+
+  return (
+    <div className="p-6 space-y-8">
+      <h1 className="text-2xl font-bold">htaccess Users</h1>
+
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="space-y-4 max-w-sm"
+        >
+          <FormField
+            control={form.control}
+            name="username"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Username</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Password</FormLabel>
+                <FormControl>
+                  <Input type="password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button type="submit">Add User</Button>
+        </form>
+      </Form>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Username</TableHead>
+            <TableHead className="w-[100px]">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {users.map((u) => (
+            <TableRow key={u.username}>
+              <TableCell>{u.username}</TableCell>
+              <TableCell>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => removeUser(u.username)}
+                >
+                  Remove
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -5,6 +5,7 @@ import { LoadingPage } from "@/components/loading";
 
 const Home = React.lazy(() => import("@/pages/home"));
 const GamesPage = React.lazy(() => import("@/pages/games-page"));
+const HtaccessAdmin = React.lazy(() => import("@/pages/htaccess-admin"));
 const NotFound = React.lazy(() => import("@/pages/not-found"));
 
 export default function AppRoutes() {
@@ -13,6 +14,7 @@ export default function AppRoutes() {
       <Switch>
         <Route path="/" component={Home} />
         <Route path="/games" component={GamesPage} />
+        <Route path="/admin/htaccess" component={HtaccessAdmin} />
         <Route component={NotFound} />
       </Switch>
     </Suspense>


### PR DESCRIPTION
## Summary
- add htaccess user management page with form and table
- wire up router to expose the htaccess admin route

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689ab13f5cd883219dd55ee145e6362a