### PR TITLE
Use bcrypt for htpasswd user management

### DIFF
--- a/backend/src/routes/admin.test.ts
+++ b/backend/src/routes/admin.test.ts
@@ -2,7 +2,8 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import express from 'express';
 import adminRouter from './admin';
-import { randomUUID, createHash } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
+import bcrypt from 'bcryptjs';
 import { env } from '../env';
 import fs from 'node:fs/promises';
 import os from 'node:os';
@@ -70,8 +71,7 @@ test('adds htaccess user', async () => {
     const contents = await fs.readFile(file, 'utf8');
     const [user, hash] = contents.trim().split(':');
     assert.equal(user, 'alice');
-    const expected = '{SHA}' + createHash('sha1').update('secret').digest('base64');
-    assert.equal(hash, expected);
+    assert.ok(bcrypt.compareSync('secret', hash));
   } finally {
     server.close();
   }
@@ -122,7 +122,7 @@ test('lists htaccess users', async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'htpasswd-'));
   const file = path.join(dir, '.htpasswd');
   env.HTPASSWD_PATH = file;
-  await fs.writeFile(file, 'alice:{SHA}hash1\n' + 'bob:{SHA}hash2\n');
+  await fs.writeFile(file, 'alice:hash1\n' + 'bob:hash2\n');
   const { server, port } = buildServer();
   try {
     const res = await fetch(`http://localhost:${port}/htaccess/users`);
@@ -138,7 +138,7 @@ test('removes htaccess user', async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'htpasswd-'));
   const file = path.join(dir, '.htpasswd');
   env.HTPASSWD_PATH = file;
-  await fs.writeFile(file, 'alice:{SHA}hash1\n' + 'bob:{SHA}hash2\n');
+  await fs.writeFile(file, 'alice:hash1\n' + 'bob:hash2\n');
   const { server, port } = buildServer();
   try {
     const res = await fetch(`http://localhost:${port}/htaccess/users/alice`, { method: 'DELETE' });
@@ -147,7 +147,7 @@ test('removes htaccess user', async () => {
     assert.deepEqual(body, { success: true });
     const contents = await fs.readFile(file, 'utf8');
     const lines = contents.trim().split('\n');
-    assert.deepEqual(lines, ['bob:{SHA}hash2']);
+    assert.deepEqual(lines, ['bob:hash2']);
   } finally {
     server.close();
   }

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
 import fs from "node:fs/promises";
-import { createHash } from "node:crypto";
+import bcrypt from "bcryptjs";
 import { env } from "../env";
 
 // Access to these routes is restricted via an API key in the `x-api-key` header.
@@ -46,8 +46,8 @@ router.post("/htaccess/users", async (req, res) => {
   }
   const { username, password } = result.data;
   try {
-    const digest = createHash("sha1").update(password).digest("base64");
-    await fs.appendFile(env.HTPASSWD_PATH, `${username}:{SHA}${digest}\n`);
+    const hash = bcrypt.hashSync(password, 10);
+    await fs.appendFile(env.HTPASSWD_PATH, `${username}:${hash}\n`);
     res.json({ success: true });
   } catch (error) {
     res.status(500).json({ error: "Failed to update htpasswd" });

--- a/docs/Backend.md
+++ b/docs/Backend.md
@@ -33,7 +33,7 @@ The admin router can manage an Apache-style `.htpasswd` file defined by `HTPASSW
 Returns the list of usernames currently in the file.
 
 ### `POST /htaccess/users`
-Adds a user. Body must contain `{ "username": string, "password": string }` and the password is stored as a SHA1 digest.
+Adds a user. Body must contain `{ "username": string, "password": string }` and the password is stored as a bcrypt hash.
 
 ### `DELETE /htaccess/users/:username`
 Removes the matching user from the file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,8 @@
         "wouter": "^3.3.5",
         "ws": "^8.18.0",
         "zod": "^3.24.2",
-        "zod-validation-error": "^3.4.0"
+        "zod-validation-error": "^3.4.0",
+        "bcryptjs": "^2.4.3"
       },
       "devDependencies": {
         "@replit/vite-plugin-cartographer": "^0.2.8",
@@ -9138,6 +9139,12 @@
       "peerDependencies": {
         "zod": "^3.18.0"
       }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "bcryptjs": "^2.4.3"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.8",


### PR DESCRIPTION
## Summary
- replace SHA-1 digests with bcrypt hashes for htpasswd entries
- update admin tests and docs to reflect bcrypt usage

## Testing
- `npm test` *(fails: Cannot find package 'bcryptjs')*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_689ab247cf74832188a777a14a60cde0