### PR TITLE
test: mock bcrypt for admin routes

### DIFF
--- a/backend/__mocks__/bcryptjs.ts
+++ b/backend/__mocks__/bcryptjs.ts
@@ -1,0 +1,22 @@
+export function hashSync(password: string, _salt: any): string {
+  return `hashed-${password}`;
+}
+
+export function compareSync(password: string, hash: string): boolean {
+  return hash === `hashed-${password}`;
+}
+
+export function hash(password: string, _salt: any, cb: (err: Error | null, hashed?: string) => void): void {
+  cb(null, hashSync(password, _salt));
+}
+
+export function compare(password: string, hash: string, cb: (err: Error | null, same?: boolean) => void): void {
+  cb(null, compareSync(password, hash));
+}
+
+export default {
+  hashSync,
+  compareSync,
+  hash,
+  compare
+};

--- a/backend/src/routes/admin.test.ts
+++ b/backend/src/routes/admin.test.ts
@@ -1,13 +1,19 @@
-import { test } from 'node:test';
+import { test, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import express from 'express';
-import adminRouter from './admin';
 import { randomUUID } from 'node:crypto';
-import bcrypt from 'bcryptjs';
 import { env } from '../env';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+
+const bcryptMock = await import('../../__mocks__/bcryptjs');
+mock.module('bcryptjs', {
+  namedExports: bcryptMock,
+  defaultExport: bcryptMock.default
+});
+const adminRouter = (await import('./admin')).default;
+const bcrypt = (await import('bcryptjs')).default;
 
 function buildServer() {
   const app = express();


### PR DESCRIPTION
## Summary
- add deterministic bcryptjs mock with sync and async APIs
- mock bcryptjs before loading admin routes tests

## Testing
- `node --experimental-test-module-mocks --import tsx --test $(find backend server -name '*.test.ts')`


------
https://chatgpt.com/codex/tasks/task_e_689ab756f65083219c67d184812aecda