### PR TITLE
feat: switch mod/admin auth to JWT

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,6 @@
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
 SUPABASE_JWKS_URL=https://your-project.supabase.co/auth/v1/.well-known/jwks.json
+JWT_SECRET=dev-secret
 PORT=4000
 CORS_ORIGIN=https://yourfrontend.com

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -1,5 +1,5 @@
 export const env = {
-  API_KEY: process.env.API_KEY || "dev-key",
+  JWT_SECRET: process.env.JWT_SECRET || "dev-secret",
   PORT: Number(process.env.PORT || 4000),
   HTPASSWD_PATH: process.env.HTPASSWD_PATH || ".htpasswd"
 };

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,20 +1,39 @@
 import { Request, Response, NextFunction } from "express";
+import { createHmac } from "node:crypto";
 import { env } from "../env";
+
+function verifyToken(token: string) {
+  const parts = token.split(".");
+  if (parts.length !== 3) throw new Error("Invalid token");
+  const [headerB64, payloadB64, signature] = parts;
+  const expected = createHmac("sha256", env.JWT_SECRET)
+    .update(`${headerB64}.${payloadB64}`)
+    .digest("base64url");
+  if (signature !== expected) throw new Error("Invalid signature");
+  const payloadJson = Buffer.from(payloadB64, "base64url").toString();
+  return JSON.parse(payloadJson);
+}
 
 export function authMiddleware(allowedRoles: string[]) {
   return (req: Request, res: Response, next: NextFunction) => {
-    const apiKey = req.header("x-api-key");
-    if (apiKey !== env.API_KEY) {
+    const auth = req.header("authorization") ?? "";
+    if (!auth.startsWith("Bearer ")) {
       return res.status(401).json({ error: "Unauthorized" });
     }
-    const rolesHeader = req.header("x-roles") ?? "";
-    const roles = rolesHeader
-      .split(",")
-      .map((r) => r.trim())
-      .filter(Boolean);
-    if (allowedRoles.length && !roles.some((r) => allowedRoles.includes(r))) {
+    try {
+      const token = auth.slice(7);
+      const payload = verifyToken(token);
+      const roles: string[] = Array.isArray(payload.roles)
+        ? payload.roles
+        : payload.role
+        ? [payload.role]
+        : [];
+      if (allowedRoles.length && !roles.some((r) => allowedRoles.includes(r))) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+      next();
+    } catch {
       return res.status(401).json({ error: "Unauthorized" });
     }
-    next();
   };
 }

--- a/backend/src/routes/admin.test.ts
+++ b/backend/src/routes/admin.test.ts
@@ -1,4 +1,4 @@
-import { test, mock } from 'node:test';
+import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import express from 'express';
 import { randomUUID } from 'node:crypto';
@@ -7,11 +7,6 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-const bcryptMock = await import('../../__mocks__/bcryptjs');
-mock.module('bcryptjs', {
-  namedExports: bcryptMock,
-  defaultExport: bcryptMock.default
-});
 const adminRouter = (await import('./admin')).default;
 const bcrypt = (await import('bcryptjs')).default;
 

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -4,8 +4,8 @@ import fs from "node:fs/promises";
 import bcrypt from "bcryptjs";
 import { env } from "../env";
 
-// Access to these routes is restricted via an API key in the `x-api-key` header.
-// Supabase is not used for authentication here.
+// Access to these routes is restricted via JWT bearer tokens with the
+// appropriate roles supplied by the authentication layer.
 const router = Router();
 
 const idSchema = z.object({ id: z.string().uuid() });

--- a/backend/src/routes/mod.ts
+++ b/backend/src/routes/mod.ts
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import { z } from "zod";
 
-// Access to these routes is restricted via an API key in the `x-api-key` header.
-// Supabase is not used for authentication here.
+// Access to these routes is restricted via JWT bearer tokens with
+// appropriate roles supplied by the authentication layer.
 const router = Router();
 
 const idSchema = z.object({ id: z.string().uuid() });

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -53,7 +53,6 @@ const SENSITIVE_HEADERS = [
   'authorization',
   'x-csrf-token',
   'x-auth-token',
-  'x-api-key',
   'x-session-token',
   'authenticate',
   'proxy-authenticate',

--- a/docs/Backend.md
+++ b/docs/Backend.md
@@ -7,11 +7,11 @@
 - Role-based auth for moderators and admins
 - Audit logging for all mod/admin actions
 - Soft delete + ban approval workflow
-- API key authentication for mod and admin routes
+ - JWT bearer authentication for mod and admin routes
 
 ## Setup
 1. Copy `.env.example` → `.env` and fill with your Supabase project details.
-2. Set `API_KEY` in `.env` to the value clients must send.
+2. Set `JWT_SECRET` in `.env` to the value used to sign authentication tokens.
 3. Install dependencies:
    ```bash
    npm install
@@ -23,7 +23,7 @@
 
 ## Authentication
 
-Requests to the `/mod` and `/admin` routes must include the API key via the `x-api-key` header. Supabase is not used for this authentication flow.
+Requests to the `/mod` and `/admin` routes must include an `Authorization` header with a valid bearer token. Tokens must be signed with `JWT_SECRET` and include the appropriate `roles` claim.
 
 ## htaccess User Management
 


### PR DESCRIPTION
## Summary
- replace x-api-key header auth with JWT bearer verification
- add JWT_SECRET config and update docs and client sensitive headers
- adjust tests and routes for role-based tokens

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689ab8f150088321a55e3d621bd6dd41