### PR TITLE
Validate backend environment configuration

### DIFF
--- a/backend/src/env.test.ts
+++ b/backend/src/env.test.ts
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envFile = join(__dirname, 'env.ts');
+
+function runEnv(env: NodeJS.ProcessEnv) {
+  const code = `import { env } from ${JSON.stringify(envFile)}; console.log(JSON.stringify(env));`;
+  return spawnSync(process.execPath, ['--import', 'tsx', '-e', code], {
+    env,
+    encoding: 'utf8'
+  });
+}
+
+test('uses defaults in development', () => {
+  const devEnv = { ...process.env, NODE_ENV: 'development' };
+  delete devEnv.JWT_SECRET;
+  delete devEnv.HTPASSWD_PATH;
+  const result = runEnv(devEnv);
+  assert.equal(result.status, 0);
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.JWT_SECRET, 'dev-secret');
+  assert.equal(parsed.HTPASSWD_PATH, '.htpasswd');
+});
+
+test('throws when required env vars missing in production', () => {
+  const prodEnv = { ...process.env, NODE_ENV: 'production' };
+  delete prodEnv.JWT_SECRET;
+  delete prodEnv.HTPASSWD_PATH;
+  const result = runEnv(prodEnv);
+  assert.notEqual(result.status, 0);
+});
+

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -1,5 +1,16 @@
-export const env = {
-  JWT_SECRET: process.env.JWT_SECRET || "dev-secret",
-  PORT: Number(process.env.PORT || 4000),
-  HTPASSWD_PATH: process.env.HTPASSWD_PATH || ".htpasswd"
-};
+import { z } from 'zod';
+
+const isProd = process.env.NODE_ENV === 'production';
+
+const envSchema = z.object({
+  JWT_SECRET: z.string().min(1),
+  PORT: z.coerce.number().int().default(4000),
+  HTPASSWD_PATH: z.string().min(1)
+});
+
+export const env = envSchema.parse({
+  JWT_SECRET: process.env.JWT_SECRET ?? (isProd ? undefined : 'dev-secret'),
+  PORT: process.env.PORT,
+  HTPASSWD_PATH: process.env.HTPASSWD_PATH ?? (isProd ? undefined : '.htpasswd')
+});
+


### PR DESCRIPTION
## Summary
- enforce backend env var validation with zod
- require JWT_SECRET and HTPASSWD_PATH in production builds
- test env defaults and misconfiguration failure cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689abab1b22883219aa340633620e62a