### PR TITLE
docs: fix privacy policy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Open a GitHub issue — we take security seriously and will address verified con
 
 ---
 
-📋 Read our full Privacy Policy: [privacy-policy.md](privacy-policy.md)
+📋 Read our full Privacy Policy: [privacy-policy.md](docs/privacy-policy.md)
 
 Spoiler: we can't access your data even if we wanted to!
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,7 +22,7 @@ Thank you for your interest in Cozy Critter!
 
 ## Code of Conduct
 
-Be respectful and inclusive. See [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) if available.
+Be respectful and inclusive. See `CODE_OF_CONDUCT.md` if available.
 
 ## Need help?
 


### PR DESCRIPTION
## Summary
- fix README privacy policy link to reference docs
- remove broken CODE_OF_CONDUCT reference in contributing guide

## Testing
- `node - <<'NODE' ...` (custom link checker)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ac3fb3d1883218a8bf1cd45b6fb82