### PR TITLE
docs: update local development instructions

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -21,20 +21,16 @@ Want to hack on Cozy Critter? Here’s how to get started.
    ```bash
    npm run dev
    ```
-   The app will be available on `http://localhost:3000` or similar.
+   The app will be available on `http://localhost:5173`.
 
 3. **Make changes**
    - Code is reloaded on save.
-   - The main app is usually in `src/`.
+   - The main app is in `client/src/`.
 
 4. **Build for production**
    ```bash
    npm run build
    ```
-
-## Linting & Formatting
-
-- Run `npm run lint` and `npm run format` (if available).
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- correct dev server URL to http://localhost:5173
- mention client code lives in client/src/
- drop lint/format references since scripts are missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ac5dd4564832192c959aaeaadad9d