### PR TITLE
Fix typo in DB README

### DIFF
--- a/README_DB.md
+++ b/README_DB.md
@@ -27,7 +27,7 @@ Run this first when re-applying to a dirty DB. It drops conflicting policies and
 ```sql
 -- Drop conflicting RLS policies safely (no-ops if missing)
 do $$
-delcare r record;
+declare r record;
 begin
   for r in
     select polname, schemaname, tablename


### PR DESCRIPTION
## Summary
- fix misspelled `declare` in database README helper script
- ensure database README ends with a newline

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689aca5c02588321a02b4089d4541302