### PR TITLE
feat: hash htaccess passwords asynchronously

### DIFF
--- a/backend/__mocks__/bcryptjs.ts
+++ b/backend/__mocks__/bcryptjs.ts
@@ -6,12 +6,30 @@ export function compareSync(password: string, hash: string): boolean {
   return hash === `hashed-${password}`;
 }
 
-export function hash(password: string, _salt: any, cb: (err: Error | null, hashed?: string) => void): void {
-  cb(null, hashSync(password, _salt));
+export function hash(
+  password: string,
+  _salt: any,
+  cb?: (err: Error | null, hashed?: string) => void
+): Promise<string> | void {
+  const result = hashSync(password, _salt);
+  if (cb) {
+    cb(null, result);
+    return;
+  }
+  return Promise.resolve(result);
 }
 
-export function compare(password: string, hash: string, cb: (err: Error | null, same?: boolean) => void): void {
-  cb(null, compareSync(password, hash));
+export function compare(
+  password: string,
+  hash: string,
+  cb?: (err: Error | null, same?: boolean) => void
+): Promise<boolean> | void {
+  const same = compareSync(password, hash);
+  if (cb) {
+    cb(null, same);
+    return;
+  }
+  return Promise.resolve(same);
 }
 
 export default {

--- a/backend/src/routes/admin.test.ts
+++ b/backend/src/routes/admin.test.ts
@@ -72,7 +72,7 @@ test('adds htaccess user', async () => {
     const contents = await fs.readFile(file, 'utf8');
     const [user, hash] = contents.trim().split(':');
     assert.equal(user, 'alice');
-    assert.ok(bcrypt.compareSync('secret', hash));
+    assert.ok(await bcrypt.compare('secret', hash));
   } finally {
     server.close();
   }

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -46,7 +46,7 @@ router.post("/htaccess/users", async (req, res) => {
   }
   const { username, password } = result.data;
   try {
-    const hash = bcrypt.hashSync(password, 10);
+    const hash = await bcrypt.hash(password, 10);
     await fs.appendFile(env.HTPASSWD_PATH, `${username}:${hash}\n`);
     res.json({ success: true });
   } catch (error) {


### PR DESCRIPTION
## Summary
- use async bcrypt hashing in admin htaccess user creation
- support promise-based hashing/compare in bcrypt mock
- adjust tests for async bcrypt compare

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689acd2c44d08321a2ba8ddb146a72b2