### PR TITLE
feat: add ping endpoint

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -9,6 +9,8 @@ const app = express();
 app.use(express.json());
 app.use(requestLogger);
 
+app.get("/ping", (_req, res) => res.json({ ok: true }));
+
 const modRoles = ["moderator", "admin"];
 const adminRoles = ["admin"];
 

--- a/backend/src/__tests__/ping.test.ts
+++ b/backend/src/__tests__/ping.test.ts
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverFile = join(__dirname, '..', '..', 'server.ts');
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function fetchWithRetry(url: string, retries = 20) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      return await fetch(url);
+    } catch {
+      await wait(100);
+    }
+  }
+  throw new Error('Server not ready');
+}
+
+test('GET /ping returns ok true', async () => {
+  const port = 5050;
+  const child = spawn(process.execPath, ['--import', 'tsx', serverFile], {
+    env: { ...process.env, PORT: String(port) },
+    stdio: 'ignore',
+  });
+
+  try {
+    const res = await fetchWithRetry(`http://localhost:${port}/ping`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(body, { ok: true });
+  } finally {
+    child.kill();
+    await new Promise((resolve) => child.on('exit', resolve));
+  }
+});


### PR DESCRIPTION
## Summary
- add public `/ping` route for health checks
- cover `/ping` route with a node test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ad2fb18c48321a623a39b7828b46f