### PR TITLE
Enforce secure CMS credentials in production

### DIFF
--- a/cms/README.md
+++ b/cms/README.md
@@ -31,6 +31,8 @@ The script verifies Node (18 or newer) and `npm`, installs packages, copies `.en
    # edit .env as needed
    ```
 
+**Security note:** Before deploying to production, set `CMS_USER` and `CMS_PASS` to secure values. The server throws an error on startup if these variables remain `admin`/`change-me` when `NODE_ENV` is `production`.
+
 ## Scripts
 - `npm run dev` – start the server in watch mode
 - `npm run build` – compile TypeScript to `dist/`

--- a/cms/src/auth.ts
+++ b/cms/src/auth.ts
@@ -1,7 +1,15 @@
 import type { Request, Response, NextFunction } from 'express';
 
-const ADMIN_USER = process.env.CMS_USER || 'admin';
-const ADMIN_PASS = process.env.CMS_PASS || 'change-me';
+const DEFAULT_USER = 'admin';
+const DEFAULT_PASS = 'change-me';
+const ADMIN_USER = process.env.CMS_USER || DEFAULT_USER;
+const ADMIN_PASS = process.env.CMS_PASS || DEFAULT_PASS;
+
+if (process.env.NODE_ENV === 'production') {
+  if (ADMIN_USER === DEFAULT_USER || ADMIN_PASS === DEFAULT_PASS) {
+    throw new Error('CMS_USER and CMS_PASS must be set to secure values in production');
+  }
+}
 
 export function requireAuth(req: Request, res: Response, next: NextFunction) {
   const auth = req.headers.authorization;


### PR DESCRIPTION
## Summary
- Fail fast during CMS auth init when default credentials are used in production
- Document need for non-default CMS_USER/CMS_PASS before deployment

## Testing
- `npm test`
- `npm --prefix cms run build`


------
https://chatgpt.com/codex/tasks/task_e_689b72cd69f483219a18136486dd20fc