### PR TITLE
feat(cms): add basic rate limiting

### DIFF
--- a/cms/README.md
+++ b/cms/README.md
@@ -6,6 +6,7 @@ A lightweight Express server that stores editable site content in local JSON fil
 - File-based storage (`cms/data/*.json`)
 - REST endpoints for public content retrieval
 - Secured admin endpoints with HTTP Basic Auth
+- Basic rate limiting to prevent abuse
 
 ## Setup
 

--- a/cms/package.json
+++ b/cms/package.json
@@ -8,7 +8,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -1,9 +1,23 @@
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import { requireAuth } from './auth.js';
 import { readData, writeData } from './storage.js';
 import { generateId } from './utils.js';
 
 const app = express();
+
+// Enable trust proxy when behind a reverse proxy (e.g., production)
+app.set('trust proxy', process.env.NODE_ENV === 'production' ? 1 : false);
+
+// Basic rate limiting
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+app.use(limiter);
 app.use(express.json());
 
 app.get('/moods', async (_req, res) => {


### PR DESCRIPTION
## Summary
- add express-rate-limit middleware to CMS
- document rate limiting in CMS README
- trust reverse proxies so rate limiting functions in production

## Testing
- `npm run build` (inside `cms`)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b77eb50fc8321b59fcd3d166b073e