### PR TITLE
chore: ignore nested env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,11 @@ build
 server/public
 
 # Environment files
-.env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+**/.env
+**/.env.local
+**/.env.development.local
+**/.env.test.local
+**/.env.production.local
 
 # IDE and editor files
 .vscode/
@@ -82,4 +82,5 @@ vite.config.ts.*
 
 # Replit specific
 .replit
+
 replit.nix


### PR DESCRIPTION
## Summary
- ignore .env files in all subdirectories to prevent committing CMS credentials

## Testing
- `npm test`
- `cd cms && npm run build`
- `npm audit` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b8da8914883218f9a34079c98f84e