### PR TITLE
feat: add theme customizer page

### DIFF
--- a/client/src/components/privacy-settings.tsx
+++ b/client/src/components/privacy-settings.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
-import { Trash2, Shield, Database, ArrowLeft, AlertTriangle, Check, Eye, Code, Globe } from "lucide-react";
+import { Trash2, Shield, Database, ArrowLeft, AlertTriangle, Check, Eye, Code, Globe, Palette } from "lucide-react";
 import { moodStorage } from "@/lib/mood-storage";
 import { Button } from "@/components/ui/button";
+import { Link } from "wouter";
 import { 
   AlertDialog, 
   AlertDialogAction, 
@@ -101,6 +102,14 @@ export function PrivacySettings({ onBack }: PrivacySettingsProps) {
           <p className="text-sm text-muted-foreground">Your data, your control</p>
         </div>
       </div>
+
+      {/* Theme Customizer Link */}
+      <Link href="/settings/theme">
+        <Button variant="outline" className="w-full justify-start gap-2">
+          <Palette size={16} />
+          Customize Theme
+        </Button>
+      </Link>
 
       {/* App Version */}
       <div className="bg-muted/30 dark:bg-muted/10 rounded-lg p-3">

--- a/client/src/pages/ThemeCustomizer.tsx
+++ b/client/src/pages/ThemeCustomizer.tsx
@@ -1,0 +1,181 @@
+import React, { useEffect, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface ThemeSettings {
+  primary: string;
+  secondary: string;
+  accent: string;
+  font: string;
+}
+
+const STORAGE_KEY = "cozy-critter-theme-settings";
+
+function hslToHex(h: number, s: number, l: number) {
+  s /= 100;
+  l /= 100;
+  const k = (n: number) => (n + h / 30) % 12;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) =>
+    Math.round(255 * (l - a * Math.max(Math.min(k(n) - 3, 9 - k(n), 1), -1)))
+      .toString(16)
+      .padStart(2, "0");
+  return `#${f(0)}${f(8)}${f(4)}`;
+}
+
+function cssVarToHex(value: string) {
+  const v = value.trim();
+  if (!v) return "#000000";
+  if (v.startsWith("#")) return v;
+  const nums = v.match(/[-\d.]+/g);
+  if (!nums) return "#000000";
+  if (v.startsWith("hsl")) {
+    const [h, s, l] = nums.map(Number);
+    return hslToHex(h, s, l);
+  }
+  if (v.startsWith("rgb")) {
+    const [r, g, b] = nums.map(Number);
+    return `#${[r, g, b]
+      .map((n) => n.toString(16).padStart(2, "0"))
+      .join("")}`;
+  }
+  return "#000000";
+}
+
+export default function ThemeCustomizer() {
+  const [settings, setSettings] = useState<ThemeSettings | null>(null);
+  const [defaults, setDefaults] = useState<ThemeSettings | null>(null);
+
+  useEffect(() => {
+    const style = getComputedStyle(document.documentElement);
+    const initial: ThemeSettings = {
+      primary: cssVarToHex(style.getPropertyValue("--primary")),
+      secondary: cssVarToHex(style.getPropertyValue("--secondary")),
+      accent: cssVarToHex(style.getPropertyValue("--accent")),
+      font: style.getPropertyValue("--font-inter").trim() || "'Inter', sans-serif",
+    };
+    setDefaults(initial);
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        const parsed: ThemeSettings = JSON.parse(stored);
+        applySettings(parsed);
+        setSettings(parsed);
+        return;
+      } catch (e) {
+        console.warn("Failed to parse theme settings", e);
+      }
+    }
+    setSettings(initial);
+  }, []);
+
+  const applySettings = (s: Partial<ThemeSettings>) => {
+    const root = document.documentElement.style;
+    if (s.primary) root.setProperty("--primary", s.primary);
+    if (s.secondary) root.setProperty("--secondary", s.secondary);
+    if (s.accent) root.setProperty("--accent", s.accent);
+    if (s.font) root.setProperty("--font-inter", s.font);
+  };
+
+  const updateSetting = (key: keyof ThemeSettings, value: string) => {
+    if (key !== "font" && !/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(value)) {
+      return;
+    }
+    const newSettings = { ...(settings as ThemeSettings), [key]: value };
+    setSettings(newSettings);
+    applySettings({ [key]: value } as Partial<ThemeSettings>);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newSettings));
+  };
+
+  const reset = () => {
+    const root = document.documentElement.style;
+    ["--primary", "--secondary", "--accent", "--font-inter"].forEach((v) =>
+      root.removeProperty(v)
+    );
+    localStorage.removeItem(STORAGE_KEY);
+    if (defaults) {
+      setSettings(defaults);
+    }
+  };
+
+  if (!settings) return null;
+
+  const fontOptions = [
+    { label: "Inter", value: "'Inter', sans-serif" },
+    { label: "Arial", value: "'Arial', sans-serif" },
+    { label: "Georgia", value: "'Georgia', serif" },
+    { label: "Comic Sans", value: "'Comic Sans MS', cursive" },
+    { label: "Courier New", value: "'Courier New', monospace" },
+  ];
+
+  return (
+    <div className="p-6 space-y-6 max-w-md mx-auto">
+      <h2 className="text-2xl font-bold">Theme Customizer</h2>
+      <form
+        className="space-y-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+        }}
+      >
+        <div className="space-y-2">
+          <Label htmlFor="primary">Primary Color</Label>
+          <Input
+            id="primary"
+            type="color"
+            value={settings.primary}
+            onChange={(e) => updateSetting("primary", e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="secondary">Secondary Color</Label>
+          <Input
+            id="secondary"
+            type="color"
+            value={settings.secondary}
+            onChange={(e) => updateSetting("secondary", e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="accent">Accent Color</Label>
+          <Input
+            id="accent"
+            type="color"
+            value={settings.accent}
+            onChange={(e) => updateSetting("accent", e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>Font</Label>
+          <Select
+            value={settings.font}
+            onValueChange={(v) => updateSetting("font", v)}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder="Select font" />
+            </SelectTrigger>
+            <SelectContent>
+              {fontOptions.map((f) => (
+                <SelectItem key={f.value} value={f.value}>
+                  {f.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="pt-2">
+          <Button type="button" variant="outline" onClick={reset}>
+            Reset to default
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -5,6 +5,7 @@ import { LoadingPage } from "@/components/loading";
 
 const Home = React.lazy(() => import("@/pages/home"));
 const GamesPage = React.lazy(() => import("@/pages/games-page"));
+const ThemeCustomizer = React.lazy(() => import("@/pages/ThemeCustomizer"));
 const NotFound = React.lazy(() => import("@/pages/not-found"));
 
 export default function AppRoutes() {
@@ -13,6 +14,7 @@ export default function AppRoutes() {
       <Switch>
         <Route path="/" component={Home} />
         <Route path="/games" component={GamesPage} />
+        <Route path="/settings/theme" component={ThemeCustomizer} />
         <Route component={NotFound} />
       </Switch>
     </Suspense>


### PR DESCRIPTION
## Summary
- add theme customizer page with color pickers and font selector
- persist customized theme variables to localStorage with reset option
- wire up `/settings/theme` route and link from privacy settings

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689bc411ee548321a5846164441f9885