### PR TITLE
feat: add drawing pad mini game

### DIFF
--- a/client/src/games/drawing-pad.tsx
+++ b/client/src/games/drawing-pad.tsx
@@ -1,0 +1,130 @@
+import React, { useRef, useState, useEffect } from 'react';
+import { GameProps } from '@/types/game';
+import { Button } from '@/components/ui/button';
+import { Square } from 'lucide-react';
+
+const COLORS = [
+  '#FCD5CE',
+  '#FDE2E4',
+  '#E2ECE9',
+  '#D3E4FD',
+  '#E7E6F7',
+  '#F9E0F7'
+];
+
+export function DrawingPad({ onComplete, onExit, config }: GameProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const isDrawing = useRef(false);
+  const startTime = useRef(Date.now());
+  const [color, setColor] = useState(COLORS[0]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.lineCap = 'round';
+    ctx.lineWidth = 4;
+  }, []);
+
+  const getPos = (e: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+    const rect = canvas.getBoundingClientRect();
+    if ('touches' in e) {
+      const touch = e.touches[0];
+      return { x: touch.clientX - rect.left, y: touch.clientY - rect.top };
+    }
+    return { x: e.nativeEvent.offsetX, y: e.nativeEvent.offsetY };
+  };
+
+  const startDrawing = (e: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>) => {
+    isDrawing.current = true;
+    const ctx = canvasRef.current?.getContext('2d');
+    if (!ctx) return;
+    const { x, y } = getPos(e);
+    ctx.strokeStyle = color;
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+  };
+
+  const draw = (e: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>) => {
+    if (!isDrawing.current) return;
+    e.preventDefault();
+    const ctx = canvasRef.current?.getContext('2d');
+    if (!ctx) return;
+    const { x, y } = getPos(e);
+    ctx.lineTo(x, y);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+  };
+
+  const stopDrawing = () => {
+    isDrawing.current = false;
+    const ctx = canvasRef.current?.getContext('2d');
+    ctx?.beginPath();
+  };
+
+  const handleComplete = () => {
+    const timeSpent = Math.round((Date.now() - startTime.current) / 1000);
+    onComplete?.({ completed: true, timeSpent, moodImpact: 'positive' });
+  };
+
+  const clearCanvas = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[400px] p-6 bg-gradient-to-br from-pink-50 to-violet-50 dark:from-pink-900/20 dark:to-violet-900/20 rounded-2xl">
+      <div className="text-center mb-4">
+        <div className="text-2xl mb-2">{config.emoji}</div>
+        <h2 className="text-xl font-bold text-foreground mb-2">{config.name}</h2>
+        <p className="text-sm text-muted-foreground">{config.description}</p>
+      </div>
+
+      <div className="flex gap-2 mb-4">
+        {COLORS.map(c => (
+          <button
+            key={c}
+            onClick={() => setColor(c)}
+            style={{ backgroundColor: c }}
+            className={`w-8 h-8 rounded-full border-2 ${color === c ? 'border-foreground' : 'border-transparent'}`}
+            aria-label="color swatch"
+          />
+        ))}
+        <Button variant="outline" size="sm" onClick={clearCanvas}>Clear</Button>
+      </div>
+
+      <canvas
+        ref={canvasRef}
+        width={320}
+        height={240}
+        className="bg-white rounded-lg border shadow-inner touch-none mb-4"
+        onMouseDown={startDrawing}
+        onMouseMove={draw}
+        onMouseUp={stopDrawing}
+        onMouseLeave={stopDrawing}
+        onTouchStart={startDrawing}
+        onTouchMove={draw}
+        onTouchEnd={stopDrawing}
+        onTouchCancel={stopDrawing}
+      />
+
+      <div className="flex gap-3">
+        <Button onClick={handleComplete} className="gap-2">
+          <Square size={16} />
+          Complete
+        </Button>
+        <Button onClick={onExit} variant="ghost">
+          Exit
+        </Button>
+      </div>
+    </div>
+  );
+}
+

--- a/client/src/games/index.ts
+++ b/client/src/games/index.ts
@@ -1,6 +1,7 @@
 // Game exports for easy importing
 export { BreathingBubble } from './breathing-bubble';
 export { ColorPattern } from './color-pattern';
+export { DrawingPad } from './drawing-pad';
 
 // This file makes it easier to add new games in the future
 // Just export them here and register them in lib/games.ts

--- a/client/src/lib/games.ts
+++ b/client/src/lib/games.ts
@@ -1,6 +1,7 @@
 import { gameRegistry } from './game-registry';
 import { BreathingBubble } from '@/games/breathing-bubble';
 import { ColorPattern } from '@/games/color-pattern';
+import { DrawingPad } from '@/games/drawing-pad';
 
 // Register all games
 gameRegistry.register({
@@ -39,6 +40,25 @@ gameRegistry.register({
     tags: ['memory', 'focus', 'patterns', 'colors', 'concentration']
   },
   Component: ColorPattern
+});
+
+gameRegistry.register({
+  config: {
+    id: 'drawing-pad',
+    name: 'Drawing Pad',
+    description: 'A simple canvas for free drawing with soft color swatches.',
+    emoji: '🎨',
+    category: 'creative',
+    difficulty: 'easy',
+    estimatedTime: '2-5 min',
+    accessibility: {
+      motionSensitive: false,
+      soundRequired: false,
+      colorBlindFriendly: true
+    },
+    tags: ['drawing', 'art', 'creative', 'expression']
+  },
+  Component: DrawingPad
 });
 
 // Export the registry for use in components


### PR DESCRIPTION
## Summary
- implement DrawingPad game for free-form canvas sketching with soft colors
- register drawing pad in game registry and export

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689bc5a3343883219a833662279bad8a