### PR TITLE
Add shape match memory mini-game

### DIFF
--- a/client/src/games/index.ts
+++ b/client/src/games/index.ts
@@ -2,6 +2,7 @@
 export { BreathingBubble } from './breathing-bubble';
 export { ColorPattern } from './color-pattern';
 export { DrawingPad } from './drawing-pad';
+export { ShapeMatch } from './shape-match';
 
 // This file makes it easier to add new games in the future
 // Just export them here and register them in lib/games.ts

--- a/client/src/games/shape-match.tsx
+++ b/client/src/games/shape-match.tsx
@@ -1,0 +1,144 @@
+import React, { useEffect, useState } from 'react';
+import { GameProps } from '@/types/game';
+import { Button } from '@/components/ui/button';
+import { RotateCcw, Circle, Square, Triangle, Star, Heart, Diamond } from 'lucide-react';
+
+interface Card {
+  id: number;
+  shape: number; // index into SHAPES
+  flipped: boolean;
+  matched: boolean;
+}
+
+const SHAPES = [
+  { name: 'Circle', Icon: Circle },
+  { name: 'Square', Icon: Square },
+  { name: 'Triangle', Icon: Triangle },
+  { name: 'Star', Icon: Star },
+  { name: 'Heart', Icon: Heart },
+  { name: 'Diamond', Icon: Diamond }
+];
+
+export function ShapeMatch({ onComplete, onExit, config }: GameProps) {
+  const [cards, setCards] = useState<Card[]>([]);
+  const [flipped, setFlipped] = useState<number[]>([]);
+  const [matches, setMatches] = useState(0);
+  const [moves, setMoves] = useState(0);
+  const [startTime] = useState(Date.now());
+  const [gameState, setGameState] = useState<'playing' | 'won'>('playing');
+
+  const shuffleCards = () => {
+    const deck: Card[] = [];
+    SHAPES.forEach((shape, index) => {
+      deck.push({ id: index * 2, shape: index, flipped: false, matched: false });
+      deck.push({ id: index * 2 + 1, shape: index, flipped: false, matched: false });
+    });
+    for (let i = deck.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [deck[i], deck[j]] = [deck[j], deck[i]];
+    }
+    setCards(deck);
+    setFlipped([]);
+    setMatches(0);
+    setMoves(0);
+    setGameState('playing');
+  };
+
+  useEffect(() => {
+    shuffleCards();
+  }, []);
+
+  const handleCardClick = (index: number) => {
+    const card = cards[index];
+    if (card.flipped || card.matched || flipped.length === 2 || gameState !== 'playing') return;
+
+    const newCards = [...cards];
+    newCards[index] = { ...card, flipped: true };
+    const newFlipped = [...flipped, index];
+    setCards(newCards);
+    setFlipped(newFlipped);
+
+    if (newFlipped.length === 2) {
+      setMoves(prev => prev + 1);
+      const [first, second] = newFlipped;
+      if (newCards[first].shape === newCards[second].shape) {
+        newCards[first].matched = true;
+        newCards[second].matched = true;
+        setCards([...newCards]);
+        setMatches(prev => prev + 1);
+        setFlipped([]);
+      } else {
+        setTimeout(() => {
+          const tempCards = [...newCards];
+          tempCards[first].flipped = false;
+          tempCards[second].flipped = false;
+          setCards(tempCards);
+          setFlipped([]);
+        }, 800);
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (matches === SHAPES.length && gameState === 'playing') {
+      setGameState('won');
+      const timeSpent = Math.round((Date.now() - startTime) / 1000);
+      onComplete?.({
+        completed: true,
+        score: matches * 10,
+        timeSpent,
+        moodImpact: 'positive'
+      });
+    }
+  }, [matches, onComplete, startTime, gameState]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[400px] p-6 bg-gradient-to-br from-yellow-50 to-orange-50 dark:from-yellow-900/20 dark:to-orange-900/20 rounded-2xl">
+      <div className="text-center mb-6">
+        <div className="text-2xl mb-2">{config.emoji}</div>
+        <h2 className="text-xl font-bold text-foreground mb-2">{config.name}</h2>
+        <p className="text-sm text-muted-foreground mb-4">{config.description}</p>
+        <div className="flex justify-center gap-4 text-sm">
+          <span className="font-medium">Moves: {moves}</span>
+          <span className="font-medium">Matches: {matches}/{SHAPES.length}</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 sm:grid-cols-4 gap-3 mb-6">
+        {cards.map((card, index) => {
+          const ShapeIcon = SHAPES[card.shape].Icon;
+          return (
+            <button
+              key={card.id}
+              onClick={() => handleCardClick(index)}
+              disabled={card.flipped || card.matched || flipped.length === 2 || gameState !== 'playing'}
+              className={`w-16 h-20 rounded-xl flex items-center justify-center bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 transition-all ${card.flipped || card.matched ? '' : 'hover:scale-105'}`}
+              aria-label={card.flipped || card.matched ? SHAPES[card.shape].name : 'hidden card'}
+            >
+              {card.flipped || card.matched ? (
+                <ShapeIcon className="w-8 h-8 text-blue-600 dark:text-blue-400" />
+              ) : (
+                <div className="w-6 h-6 bg-gray-300 dark:bg-gray-600 rounded" />
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {gameState === 'won' && (
+        <div className="text-green-600 dark:text-green-400 font-medium mb-4">Great job! You found all the matches.</div>
+      )}
+
+      <div className="flex gap-3 flex-wrap justify-center">
+        <Button onClick={shuffleCards} variant="outline" className="gap-2">
+          <RotateCcw size={16} />
+          Reset
+        </Button>
+        <Button onClick={onExit} variant="ghost">
+          Exit
+        </Button>
+      </div>
+    </div>
+  );
+}
+

--- a/client/src/lib/games.test.tsx
+++ b/client/src/lib/games.test.tsx
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import MiniGames from '@/pages/mini-games';
+import { gameRegistry } from '@/lib/games';
+import { GameResult } from '@/types/game';
+
+// Verify the shape-match game is registered correctly
+
+test('shape-match game registered under focus category', () => {
+  const game = gameRegistry.getGame('shape-match');
+  assert.ok(game, 'shape-match game should be registered');
+  assert.equal(game!.config.category, 'focus');
+});
+
+// Verify MiniGames renders the shape-match card
+
+test('MiniGames lists the Shape Match game', () => {
+  const html = renderToString(<MiniGames onBack={() => {}} />);
+  assert.ok(html.includes('Shape Match'));
+});
+
+// Verify completion handler logic
+test('onComplete marks game as completed', () => {
+  const game = gameRegistry.getGame('shape-match');
+  let completed: string[] = [];
+  const handleGameComplete = (result: GameResult) => {
+    if (result.completed && game) {
+      completed = [...completed, game.config.id];
+    }
+  };
+
+  handleGameComplete({ completed: true, timeSpent: 1 });
+  assert.deepEqual(completed, ['shape-match']);
+});

--- a/client/src/lib/games.ts
+++ b/client/src/lib/games.ts
@@ -2,6 +2,7 @@ import { gameRegistry } from './game-registry';
 import { BreathingBubble } from '@/games/breathing-bubble';
 import { ColorPattern } from '@/games/color-pattern';
 import { DrawingPad } from '@/games/drawing-pad';
+import { ShapeMatch } from '@/games/shape-match';
 
 // Register all games
 gameRegistry.register({
@@ -40,6 +41,25 @@ gameRegistry.register({
     tags: ['memory', 'focus', 'patterns', 'colors', 'concentration']
   },
   Component: ColorPattern
+});
+
+gameRegistry.register({
+  config: {
+    id: 'shape-match',
+    name: 'Shape Match',
+    description: 'Flip cards to find matching shapes. A gentle memory challenge.',
+    emoji: '🔷',
+    category: 'focus',
+    difficulty: 'easy',
+    estimatedTime: '2-5 min',
+    accessibility: {
+      motionSensitive: false,
+      soundRequired: false,
+      colorBlindFriendly: true
+    },
+    tags: ['memory', 'matching', 'shapes', 'focus']
+  },
+  Component: ShapeMatch
 });
 
 gameRegistry.register({


### PR DESCRIPTION
## Summary
- add shape-match card-flipping memory game
- register new game in game registry
- basic tests for registry, MiniGames listing, and completion handler

## Testing
- `npm test`
- `npm run check`
- `node --import tsx --test client/src/lib/games.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689bc813666483219e1ffc369e3ad744