### PR TITLE
Add completed and favorite filters for mini games

### DIFF
--- a/client/src/lib/game-progress.ts
+++ b/client/src/lib/game-progress.ts
@@ -6,6 +6,7 @@ export interface GameProgressEntry {
   completed: boolean;
   lastPlayed: number;
   highScore?: number;
+  favorite?: boolean;
 }
 
 interface GameProgressMap {
@@ -30,9 +31,23 @@ export function getCompletedGames(): string[] {
   return Object.keys(progress).filter((id) => progress[id].completed);
 }
 
+export function getFavoriteGames(): string[] {
+  const progress = loadProgress();
+  return Object.keys(progress).filter((id) => progress[id].favorite);
+}
+
 export function getGameData(id: string): GameProgressEntry | undefined {
   const progress = loadProgress();
   return progress[id];
+}
+
+export function toggleFavoriteGame(id: string): boolean {
+  const progress = loadProgress();
+  const existing = progress[id] || { completed: false, lastPlayed: 0 };
+  const favorite = !existing.favorite;
+  progress[id] = { ...existing, favorite };
+  saveProgress(progress);
+  return favorite;
 }
 
 export function markGameCompleted(id: string, result?: GameResult): void {
@@ -44,6 +59,7 @@ export function markGameCompleted(id: string, result?: GameResult): void {
       : existing?.highScore;
 
   progress[id] = {
+    ...existing,
     completed: true,
     lastPlayed: Date.now(),
     highScore,

--- a/client/src/pages/mini-games.tsx
+++ b/client/src/pages/mini-games.tsx
@@ -1,9 +1,15 @@
 import React, { useState } from 'react';
-import { ArrowLeft, Filter, Star, Clock, Target } from 'lucide-react';
+import { ArrowLeft, Filter, Star, Clock, Target, Heart } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { gameRegistry } from '@/lib/games';
 import { Game, GameConfig, GameResult } from '@/types/game';
-import { getCompletedGames, markGameCompleted, getGameData } from '@/lib/game-progress';
+import {
+  getCompletedGames,
+  getFavoriteGames,
+  markGameCompleted,
+  getGameData,
+  toggleFavoriteGame,
+} from '@/lib/game-progress';
 
 interface MiniGamesProps {
   onBack: () => void;
@@ -11,13 +17,20 @@ interface MiniGamesProps {
 
 export default function MiniGames({ onBack }: MiniGamesProps) {
   const [currentGame, setCurrentGame] = useState<Game | null>(null);
-  const [filter, setFilter] = useState<GameConfig['category'] | 'all'>('all');
+  const [filter, setFilter] =
+    useState<GameConfig['category'] | 'all' | 'completed' | 'favorites'>('all');
   const [completedGames, setCompletedGames] = useState<string[]>(() => getCompletedGames());
+  const [favoriteGames, setFavoriteGames] = useState<string[]>(() => getFavoriteGames());
 
   const allGames = gameRegistry.getAllGames();
-  const filteredGames = filter === 'all' 
-    ? allGames 
-    : gameRegistry.getGamesByCategory(filter);
+  const filteredGames =
+    filter === 'all'
+      ? allGames
+      : filter === 'completed'
+      ? allGames.filter((g) => completedGames.includes(g.config.id))
+      : filter === 'favorites'
+      ? allGames.filter((g) => favoriteGames.includes(g.config.id))
+      : gameRegistry.getGamesByCategory(filter);
 
   const handleGameComplete = (result: GameResult) => {
     if (currentGame) {
@@ -31,6 +44,11 @@ export default function MiniGames({ onBack }: MiniGamesProps) {
 
   const handleGameExit = () => {
     setCurrentGame(null);
+  };
+
+  const handleToggleFavorite = (id: string) => {
+    toggleFavoriteGame(id);
+    setFavoriteGames(getFavoriteGames());
   };
 
   const getCategoryIcon = (category: GameConfig['category']) => {
@@ -107,7 +125,17 @@ export default function MiniGames({ onBack }: MiniGamesProps) {
 
       {/* Filter Tabs */}
       <div className="flex flex-wrap gap-2">
-        {(['all', 'calming', 'focus', 'sensory', 'creative'] as const).map((category) => (
+        {(
+          [
+            'all',
+            'completed',
+            'favorites',
+            'calming',
+            'focus',
+            'sensory',
+            'creative',
+          ] as const
+        ).map((category) => (
           <Button
             key={category}
             onClick={() => setFilter(category)}
@@ -115,8 +143,20 @@ export default function MiniGames({ onBack }: MiniGamesProps) {
             size="sm"
             className="gap-2"
           >
-            <Filter size={14} />
-            {category === 'all' ? 'All Games' : category.charAt(0).toUpperCase() + category.slice(1)}
+            {category === 'completed' ? (
+              <Star size={14} />
+            ) : category === 'favorites' ? (
+              <Heart size={14} />
+            ) : (
+              <Filter size={14} />
+            )}
+            {category === 'all'
+              ? 'All Games'
+              : category === 'completed'
+              ? 'Completed'
+              : category === 'favorites'
+              ? 'Favorites'
+              : category.charAt(0).toUpperCase() + category.slice(1)}
           </Button>
         ))}
       </div>
@@ -145,14 +185,28 @@ export default function MiniGames({ onBack }: MiniGamesProps) {
                   </p>
                 </div>
               </div>
-              <div className="text-right">
-                <div className="text-xs text-muted-foreground flex items-center gap-1 mb-1">
-                  <Clock size={12} />
-                  {game.config.estimatedTime}
-                </div>
-                <div className="text-xs text-muted-foreground flex items-center gap-1">
-                  <Target size={12} />
-                  {game.config.difficulty}
+              <div className="flex items-start gap-2">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleToggleFavorite(game.config.id)}
+                  className="h-6 w-6 p-0"
+                  aria-label="Toggle favorite"
+                >
+                  <Heart
+                    size={16}
+                    className={favoriteGames.includes(game.config.id) ? 'text-red-500 fill-current' : ''}
+                  />
+                </Button>
+                <div className="text-right">
+                  <div className="text-xs text-muted-foreground flex items-center gap-1 mb-1">
+                    <Clock size={12} />
+                    {game.config.estimatedTime}
+                  </div>
+                  <div className="text-xs text-muted-foreground flex items-center gap-1">
+                    <Target size={12} />
+                    {game.config.difficulty}
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- track favorite games in progress storage
- add "Completed" and "Favorites" filter tabs for mini games
- allow toggling favorites with a heart icon on each game card

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd091b9908321a076b64253648034