### PR TITLE
feat: add game instructions modal

### DIFF
--- a/client/src/components/game-instructions.tsx
+++ b/client/src/components/game-instructions.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+
+interface GameInstructionsProps {
+  open: boolean;
+  title: string;
+  description: string;
+  gameId: string;
+  onStart: () => void;
+  onClose: () => void;
+}
+
+export function GameInstructions({ open, title, description, gameId, onStart, onClose }: GameInstructionsProps) {
+  const [skip, setSkip] = useState(false);
+
+  const handleStart = () => {
+    if (skip) {
+      localStorage.setItem(`skip-instructions-${gameId}`, 'true');
+    }
+    onStart();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="flex items-center space-x-2 py-4">
+          <Checkbox id="skip" checked={skip} onCheckedChange={(value) => setSkip(!!value)} />
+          <Label htmlFor="skip" className="text-sm">Don't show again</Label>
+        </div>
+        <DialogFooter>
+          <Button onClick={handleStart}>Start</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/pages/mini-games.tsx
+++ b/client/src/pages/mini-games.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { gameRegistry } from '@/lib/games';
 import { Game, GameConfig, GameResult } from '@/types/game';
 import { getCompletedGames, markGameCompleted, getGameData } from '@/lib/game-progress';
+import { GameInstructions } from '@/components/game-instructions';
 
 interface MiniGamesProps {
   onBack: () => void;
@@ -11,6 +12,7 @@ interface MiniGamesProps {
 
 export default function MiniGames({ onBack }: MiniGamesProps) {
   const [currentGame, setCurrentGame] = useState<Game | null>(null);
+  const [pendingGame, setPendingGame] = useState<Game | null>(null);
   const [filter, setFilter] = useState<GameConfig['category'] | 'all'>('all');
   const [completedGames, setCompletedGames] = useState<string[]>(() => getCompletedGames());
 
@@ -31,6 +33,26 @@ export default function MiniGames({ onBack }: MiniGamesProps) {
 
   const handleGameExit = () => {
     setCurrentGame(null);
+  };
+
+  const handleSelectGame = (game: Game) => {
+    const skip = localStorage.getItem(`skip-instructions-${game.config.id}`) === 'true';
+    if (skip) {
+      setCurrentGame(game);
+    } else {
+      setPendingGame(game);
+    }
+  };
+
+  const handleStartPendingGame = () => {
+    if (pendingGame) {
+      setCurrentGame(pendingGame);
+      setPendingGame(null);
+    }
+  };
+
+  const handleCloseInstructions = () => {
+    setPendingGame(null);
   };
 
   const getCategoryIcon = (category: GameConfig['category']) => {
@@ -209,7 +231,7 @@ export default function MiniGames({ onBack }: MiniGamesProps) {
             )}
 
             <Button
-              onClick={() => setCurrentGame(game)}
+              onClick={() => handleSelectGame(game)}
               className="w-full"
             >
               {completedGames.includes(game.config.id) ? 'Play Again' : 'Start Game'}
@@ -236,6 +258,17 @@ export default function MiniGames({ onBack }: MiniGamesProps) {
           We're working on more sensory-friendly games including drawing pads, gentle puzzles, and stim-friendly activities.
         </p>
       </div>
+
+      {pendingGame && (
+        <GameInstructions
+          open={!!pendingGame}
+          gameId={pendingGame.config.id}
+          title={pendingGame.config.name}
+          description={pendingGame.config.description}
+          onStart={handleStartPendingGame}
+          onClose={handleCloseInstructions}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable game instructions modal with skip preference
- show instructions before starting mini-games

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689bd0be17a48321ab8d47dfdc2f7cff