### PR TITLE
feat(cms): add Netlify CMS previews

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -7,7 +7,18 @@
   </head>
   <body>
     <div id="cms"></div>
-    <script>
+    <script type="module">
+      import MoodsPreview from './previews/moods.js';
+      import GamesPreview from './previews/games.js';
+      import PagesPreview from './previews/pages.js';
+
+      CMS.registerPreviewStyle('https://cdn.jsdelivr.net/npm/tailwindcss@3.4.17/dist/tailwind.min.css');
+      CMS.registerPreviewStyle('https://cdn.jsdelivr.net/npm/@tailwindcss/typography@0.5.15/dist/typography.min.css');
+
+      CMS.registerPreviewTemplate('moods', MoodsPreview);
+      CMS.registerPreviewTemplate('games', GamesPreview);
+      CMS.registerPreviewTemplate('pages', PagesPreview);
+
       CMS.init({ element: document.getElementById('cms') });
     </script>
   </body>

--- a/public/admin/previews/games.js
+++ b/public/admin/previews/games.js
@@ -1,0 +1,20 @@
+const React = window.React;
+
+export default function GamesPreview({ entry }) {
+  const data = entry.getIn(['data', 'games']);
+  const games = data ? data.toJS() : [];
+
+  return React.createElement(
+    'div',
+    { className: 'space-y-6 p-4' },
+    games.map((game, index) =>
+      React.createElement(
+        'div',
+        { key: index, className: 'p-4 border rounded-lg shadow-sm' },
+        React.createElement('h2', { className: 'text-lg font-semibold mb-2' }, game.title),
+        React.createElement('p', { className: 'mb-2 text-sm text-muted-foreground' }, game.description),
+        React.createElement('a', { href: game.url, className: 'text-primary underline' }, game.url)
+      )
+    )
+  );
+}

--- a/public/admin/previews/moods.js
+++ b/public/admin/previews/moods.js
@@ -1,0 +1,26 @@
+const React = window.React;
+
+export default function MoodsPreview({ entry }) {
+  const data = entry.getIn(['data', 'moods']);
+  const moods = data ? data.toJS() : [];
+
+  return React.createElement(
+    'div',
+    { className: 'grid grid-cols-2 gap-4 p-4' },
+    moods.map((mood, index) =>
+      React.createElement(
+        'div',
+        {
+          key: index,
+          className: `p-6 rounded-2xl shadow-md text-center ${mood.color}`,
+        },
+        React.createElement('div', { className: 'text-4xl mb-3' }, mood.emoji),
+        React.createElement(
+          'div',
+          { className: 'text-brown dark:text-brown font-medium' },
+          mood.mood
+        )
+      )
+    )
+  );
+}

--- a/public/admin/previews/pages.js
+++ b/public/admin/previews/pages.js
@@ -1,0 +1,22 @@
+const React = window.React;
+const md = window.markdownit();
+
+export default function PagesPreview({ entry }) {
+  const data = entry.getIn(['data', 'pages']);
+  const pages = data ? data.toJS() : [];
+
+  return React.createElement(
+    'div',
+    { className: 'space-y-10 p-4' },
+    pages.map((page, index) =>
+      React.createElement(
+        'article',
+        { key: index, className: 'prose mx-auto' },
+        React.createElement('h1', { className: 'text-2xl font-bold mb-4' }, page.title),
+        React.createElement('div', {
+          dangerouslySetInnerHTML: { __html: md.render(page.body || '') },
+        })
+      )
+    )
+  );
+}


### PR DESCRIPTION
## Summary
- add React preview components for moods, games, and pages
- register previews and load Tailwind styles in CMS admin

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689bdddc8d208321a9d4ee628c8d6cd8