### PR TITLE
Enable CMS editorial workflow and Netlify build trigger

### DIFF
--- a/.github/workflows/netlify-build.yml
+++ b/.github/workflows/netlify-build.yml
@@ -1,0 +1,19 @@
+name: Trigger Netlify build
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Netlify build
+        env:
+          NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}
+        run: |
+          if [ -n "$NETLIFY_BUILD_HOOK" ]; then
+            curl -X POST -d '{}' "$NETLIFY_BUILD_HOOK"
+          else
+            echo "NETLIFY_BUILD_HOOK secret is not set"
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,16 @@ Thanks for helping make Cozy Critter better!
 - `npm run check` – TypeScript checks
 - `npm test` – run tests
 
+## Editorial workflow
+
+Content edited in Decap CMS uses an editorial workflow with three stages:
+
+1. **Draft** – save unfinished work.
+2. **In Review** – submit for maintainer review.
+3. **Ready** – approved content that can be merged and published.
+
+Once changes reach the Ready stage and are merged into `main`, a Netlify build hook deploys the updated site.
+
 ## Pull Request Checklist
 
 - [ ] Tests pass (`npm test`)

--- a/docs/decap-cms.md
+++ b/docs/decap-cms.md
@@ -20,6 +20,16 @@ Use the interface to add, update, or remove entries. Changes are written as comm
 
 When you publish, Decap CMS commits the updated JSON files. Redeploy your site so the new content is served.
 
+## Editorial workflow
+
+Decap CMS organizes unpublished content into three status columns:
+
+- **Draft** – initial saves that are still being written.
+- **In Review** – content submitted for approval.
+- **Ready** – approved entries ready to publish.
+
+Editors move entries through these columns so only reviewed content is merged and deployed.
+
 ## Local development
 
 Run the development server and open `http://localhost:5000/admin/` (adjust the port if needed). The CMS will write directly to your local Git repo.

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -7,6 +7,7 @@ backend:
   ## Use GitHub's implicit OAuth flow for authentication.
   auth_type: implicit
   ## Access is restricted to GitHub collaborators with write permissions.
+publish_mode: editorial_workflow
 media_folder: "public/uploads"
 public_folder: "/uploads"
 collections:


### PR DESCRIPTION
## Summary
- enable Decap CMS editorial workflow
- document Draft → In Review → Ready content process
- trigger Netlify build after merges to `main`

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689bdf36e2d0832186ff023ad1c078a6