### PR TITLE
feat(admin): add custom CMS widgets

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -20,7 +20,7 @@ collections:
         fields:
           - { label: "Emoji", name: "emoji", widget: "string" }
           - { label: "Mood", name: "mood", widget: "string" }
-          - { label: "Color", name: "color", widget: "string" }
+          - { label: "Color", name: "color", widget: "mood-color" }
   - name: "games"
     label: "Games"
     file: "content/games.json"
@@ -32,6 +32,7 @@ collections:
           - { label: "Title", name: "title", widget: "string" }
           - { label: "URL", name: "url", widget: "string" }
           - { label: "Description", name: "description", widget: "text" }
+          - { label: "Difficulty", name: "difficulty", widget: "game-difficulty" }
   - name: "pages"
     label: "Pages"
     file: "content/pages.json"

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -11,6 +11,8 @@
       import MoodsPreview from './previews/moods.js';
       import GamesPreview from './previews/games.js';
       import PagesPreview from './previews/pages.js';
+      import GameDifficultyWidget from './widgets/game-difficulty.js';
+      import MoodColorWidget from './widgets/mood-color.js';
 
       CMS.registerPreviewStyle('https://cdn.jsdelivr.net/npm/tailwindcss@3.4.17/dist/tailwind.min.css');
       CMS.registerPreviewStyle('https://cdn.jsdelivr.net/npm/@tailwindcss/typography@0.5.15/dist/typography.min.css');
@@ -18,6 +20,9 @@
       CMS.registerPreviewTemplate('moods', MoodsPreview);
       CMS.registerPreviewTemplate('games', GamesPreview);
       CMS.registerPreviewTemplate('pages', PagesPreview);
+
+      CMS.registerWidget('game-difficulty', GameDifficultyWidget.control, GameDifficultyWidget.preview);
+      CMS.registerWidget('mood-color', MoodColorWidget.control, MoodColorWidget.preview);
 
       CMS.init({ element: document.getElementById('cms') });
     </script>

--- a/public/admin/widgets/game-difficulty.js
+++ b/public/admin/widgets/game-difficulty.js
@@ -1,0 +1,21 @@
+const React = window.React;
+const h = React.createElement;
+
+const GameDifficultyControl = ({ value, onChange }) =>
+  h(
+    'select',
+    { value: value || 'easy', onChange: e => onChange(e.target.value) },
+    [
+      h('option', { value: 'easy' }, 'Easy'),
+      h('option', { value: 'medium' }, 'Medium'),
+      h('option', { value: 'hard' }, 'Hard'),
+    ]
+  );
+
+const GameDifficultyPreview = ({ value }) =>
+  h('span', null, value);
+
+export default {
+  control: GameDifficultyControl,
+  preview: GameDifficultyPreview,
+};

--- a/public/admin/widgets/mood-color.js
+++ b/public/admin/widgets/mood-color.js
@@ -1,0 +1,24 @@
+const React = window.React;
+const h = React.createElement;
+
+const MoodColorControl = ({ value, onChange }) =>
+  h('input', {
+    type: 'color',
+    value: value || '#000000',
+    onChange: e => onChange(e.target.value),
+  });
+
+const MoodColorPreview = ({ value }) =>
+  h('div', {
+    style: {
+      display: 'inline-block',
+      width: '1.5em',
+      height: '1.5em',
+      backgroundColor: value,
+    },
+  });
+
+export default {
+  control: MoodColorControl,
+  preview: MoodColorPreview,
+};


### PR DESCRIPTION
## Summary
- add game difficulty and mood color widgets
- register custom widgets in Decap CMS
- apply widgets to moods and games fields

## Testing
- `npm run -s check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bdf3f384c832186c11488ffe68f4e