### PR TITLE
Add Zen Blocks calming mini-game and summary modal

### DIFF
--- a/client/src/games/index.ts
+++ b/client/src/games/index.ts
@@ -3,6 +3,7 @@ export { BreathingBubble } from './breathing-bubble';
 export { ColorPattern } from './color-pattern';
 export { DrawingPad } from './drawing-pad';
 export { ShapeMatch } from './shape-match';
+export { ZenBlocks } from './zen-blocks';
 
 // This file makes it easier to add new games in the future
 // Just export them here and register them in lib/games.ts

--- a/client/src/games/zen-blocks.tsx
+++ b/client/src/games/zen-blocks.tsx
@@ -1,0 +1,171 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { GameProps } from '@/types/game';
+import { Button } from '@/components/ui/button';
+
+const COLS = 10;
+const ROWS = 20;
+
+const createEmptyGrid = () => Array.from({ length: ROWS }, () => Array(COLS).fill(0));
+
+export function ZenBlocks({ onComplete, onExit, config }: GameProps) {
+  const [grid, setGrid] = useState<number[][]>(createEmptyGrid);
+  const [piece, setPiece] = useState<{ x: number; y: number }>({
+    x: Math.floor(COLS / 2),
+    y: 0,
+  });
+  const [lines, setLines] = useState(0);
+  const [startTime] = useState(Date.now());
+  const audioCtxRef = useRef<AudioContext | null>(null);
+
+  const canMove = (x: number, y: number) => {
+    if (x < 0 || x >= COLS || y >= ROWS) return false;
+    return !grid[y][x];
+  };
+
+  const playTone = (frequency: number) => {
+    try {
+      let ctx = audioCtxRef.current;
+      if (!ctx) {
+        ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+        audioCtxRef.current = ctx;
+      }
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.frequency.value = frequency;
+      gain.gain.value = 0.05;
+      osc.connect(gain).connect(ctx.destination);
+      osc.start();
+      osc.stop(ctx.currentTime + 0.15);
+    } catch {
+      // ignore audio errors
+    }
+  };
+
+  const spawnPiece = (g: number[][]) => {
+    const startX = Math.floor(COLS / 2);
+    if (g[0][startX]) {
+      // board full - gently reset
+      g = createEmptyGrid();
+    }
+    setGrid(g);
+    setPiece({ x: startX, y: 0 });
+  };
+
+  const lockPiece = (x: number, y: number) => {
+    const newGrid = grid.map((row) => [...row]);
+    if (newGrid[y] && !newGrid[y][x]) {
+      newGrid[y][x] = 1;
+    } else {
+      // spawning into filled space clears board
+      spawnPiece(createEmptyGrid());
+      return;
+    }
+
+    let cleared = 0;
+    for (let r = ROWS - 1; r >= 0; r--) {
+      if (newGrid[r].every((cell) => cell === 1)) {
+        newGrid.splice(r, 1);
+        newGrid.unshift(Array(COLS).fill(0));
+        cleared++;
+      }
+    }
+    if (cleared > 0) {
+      playTone(440);
+      setLines((l) => l + cleared);
+    } else {
+      playTone(220);
+    }
+
+    spawnPiece(newGrid);
+  };
+
+  const dropPiece = () => {
+    setPiece((prev) => {
+      if (canMove(prev.x, prev.y + 1)) {
+        return { ...prev, y: prev.y + 1 };
+      }
+      lockPiece(prev.x, prev.y);
+      return prev;
+    });
+  };
+
+  useEffect(() => {
+    const interval = setInterval(dropPiece, 1000);
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [grid]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft' && canMove(piece.x - 1, piece.y)) {
+        setPiece((p) => ({ ...p, x: p.x - 1 }));
+      } else if (e.key === 'ArrowRight' && canMove(piece.x + 1, piece.y)) {
+        setPiece((p) => ({ ...p, x: p.x + 1 }));
+      } else if (e.key === 'ArrowDown') {
+        dropPiece();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [piece, grid]);
+
+  const resetGame = () => {
+    setGrid(createEmptyGrid());
+    setLines(0);
+    setPiece({ x: Math.floor(COLS / 2), y: 0 });
+  };
+
+  const endSession = () => {
+    const timeSpent = Math.round((Date.now() - startTime) / 1000);
+    onComplete?.({
+      completed: true,
+      score: lines,
+      timeSpent,
+      moodImpact: 'calming',
+    });
+  };
+
+  const displayGrid = grid.map((row) => [...row]);
+  if (piece.y >= 0 && piece.y < ROWS) {
+    displayGrid[piece.y][piece.x] = 2;
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[400px] p-6 bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-2xl">
+      <div className="text-center mb-4">
+        <div className="text-2xl mb-2">{config.emoji}</div>
+        <h2 className="text-xl font-bold text-foreground mb-2">{config.name}</h2>
+        <p className="text-sm text-muted-foreground mb-4">{config.description}</p>
+        <div className="flex justify-center gap-4 text-sm">
+          <span className="font-medium">Lines: {lines}</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-10 gap-px bg-gray-300 dark:bg-gray-700 p-1 rounded">
+        {displayGrid.flat().map((cell, idx) => (
+          <div
+            key={idx}
+            className={`w-6 h-6 ${
+              cell === 0
+                ? 'bg-white dark:bg-gray-800'
+                : cell === 1
+                ? 'bg-purple-400 dark:bg-purple-600'
+                : 'bg-purple-300 dark:bg-purple-500'
+            }`}
+          />
+        ))}
+      </div>
+
+      <div className="flex gap-3 flex-wrap justify-center mt-6">
+        <Button onClick={resetGame} variant="outline">
+          Reset
+        </Button>
+        <Button onClick={endSession}>End Session</Button>
+        <Button onClick={onExit} variant="ghost">
+          Exit
+        </Button>
+      </div>
+    </div>
+  );
+}
+

--- a/client/src/lib/games.test.tsx
+++ b/client/src/lib/games.test.tsx
@@ -14,6 +14,13 @@ test('shape-match game registered under focus category', () => {
   assert.equal(game!.config.category, 'focus');
 });
 
+// Verify zen-blocks game is registered correctly
+test('zen-blocks game registered under calming category', () => {
+  const game = gameRegistry.getGame('zen-blocks');
+  assert.ok(game, 'zen-blocks game should be registered');
+  assert.equal(game!.config.category, 'calming');
+});
+
 // Verify MiniGames renders the shape-match card
 
 test('MiniGames lists the Shape Match game', () => {

--- a/client/src/lib/games.ts
+++ b/client/src/lib/games.ts
@@ -3,6 +3,7 @@ import { BreathingBubble } from '@/games/breathing-bubble';
 import { ColorPattern } from '@/games/color-pattern';
 import { DrawingPad } from '@/games/drawing-pad';
 import { ShapeMatch } from '@/games/shape-match';
+import { ZenBlocks } from '@/games/zen-blocks';
 
 // Register all games
 gameRegistry.register({
@@ -78,7 +79,26 @@ gameRegistry.register({
     },
     tags: ['drawing', 'art', 'creative', 'expression']
   },
-  Component: DrawingPad
+    Component: DrawingPad
+  });
+
+gameRegistry.register({
+  config: {
+    id: 'zen-blocks',
+    name: 'Zen Blocks',
+    description: 'A relaxing block-stacking game with slow falling pieces and no game over.',
+    emoji: '🧘',
+    category: 'calming',
+    difficulty: 'easy',
+    estimatedTime: '5-10 min',
+    accessibility: {
+      motionSensitive: false,
+      soundRequired: false,
+      colorBlindFriendly: true
+    },
+    tags: ['blocks', 'calming', 'focus', 'tetris']
+  },
+  Component: ZenBlocks
 });
 
 // Export the registry for use in components

--- a/client/src/pages/mini-games.tsx
+++ b/client/src/pages/mini-games.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { ArrowLeft, Filter, Star, Clock, Target, Heart } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
 import { gameRegistry } from '@/lib/games';
 import { Game, GameConfig, GameResult } from '@/types/game';
 import {
@@ -20,6 +21,7 @@ interface MiniGamesProps {
 export default function MiniGames({ onBack }: MiniGamesProps) {
   const [currentGame, setCurrentGame] = useState<Game | null>(null);
   const [pendingGame, setPendingGame] = useState<Game | null>(null);
+  const [summary, setSummary] = useState<{ game: Game; result: GameResult } | null>(null);
   const [filter, setFilter] = useState<
     GameConfig['category'] | 'all' | 'completed' | 'favorites'
   >('all');
@@ -42,6 +44,7 @@ export default function MiniGames({ onBack }: MiniGamesProps) {
         markGameCompleted(currentGame.config.id, result);
         setCompletedGames(getCompletedGames());
       }
+      setSummary({ game: currentGame, result });
       setCurrentGame(null);
     }
   };
@@ -323,6 +326,37 @@ export default function MiniGames({ onBack }: MiniGamesProps) {
           onStart={handleStartPendingGame}
           onClose={handleCloseInstructions}
         />
+      )}
+
+      {summary && (
+        <Dialog open onOpenChange={(o) => { if (!o) setSummary(null); }}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{summary.game.config.name} Complete</DialogTitle>
+              <DialogDescription>
+                {summary.result.completed ? 'Great job taking a mindful break!' : 'Session ended.'}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="py-4 text-sm space-y-1">
+              <div>Time: {summary.result.timeSpent}s</div>
+              {typeof summary.result.score === 'number' && (
+                <div>Score: {summary.result.score}</div>
+              )}
+            </div>
+            <DialogFooter className="justify-between">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setSummary(null);
+                  setCurrentGame(summary.game);
+                }}
+              >
+                Play Again
+              </Button>
+              <Button onClick={() => setSummary(null)}>Back</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add Zen Blocks, a slow-paced block game with gentle sounds and no game over
- export and register Zen Blocks with calming description
- show post-game summary modal with Play Again or Back options

## Testing
- `npm test`
- `node --import tsx client/src/lib/games.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689bd725d6c883219028423e7e21a6c5