### PR TITLE
Ensure admin panel gets published in client build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "npm run dev:web",
     "dev:web": "vite",
     "dev:server": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && cp -r public/admin client/dist/admin && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "preview": "vite preview",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -13,34 +13,43 @@ public_folder: "/uploads"
 collections:
   - name: "moods"
     label: "Moods"
-    file: "content/moods.json"
-    fields:
-      - label: "Moods"
-        name: "moods"
-        widget: "list"
+    files:
+      - name: "moods"
+        label: "Moods"
+        file: "content/moods.json"
         fields:
-          - { label: "Emoji", name: "emoji", widget: "string" }
-          - { label: "Mood", name: "mood", widget: "string" }
-          - { label: "Color", name: "color", widget: "mood-color" }
+          - label: "Moods"
+            name: "moods"
+            widget: "list"
+            fields:
+              - { label: "Emoji", name: "emoji", widget: "string" }
+              - { label: "Mood", name: "mood", widget: "string" }
+              - { label: "Color", name: "color", widget: "mood-color" }
   - name: "games"
     label: "Games"
-    file: "content/games.json"
-    fields:
-      - label: "Games"
-        name: "games"
-        widget: "list"
+    files:
+      - name: "games"
+        label: "Games"
+        file: "content/games.json"
         fields:
-          - { label: "Title", name: "title", widget: "string" }
-          - { label: "URL", name: "url", widget: "string" }
-          - { label: "Description", name: "description", widget: "text" }
-          - { label: "Difficulty", name: "difficulty", widget: "game-difficulty" }
+          - label: "Games"
+            name: "games"
+            widget: "list"
+            fields:
+              - { label: "Title", name: "title", widget: "string" }
+              - { label: "URL", name: "url", widget: "string" }
+              - { label: "Description", name: "description", widget: "text" }
+              - { label: "Difficulty", name: "difficulty", widget: "game-difficulty" }
   - name: "pages"
     label: "Pages"
-    file: "content/pages.json"
-    fields:
-      - label: "Pages"
-        name: "pages"
-        widget: "list"
+    files:
+      - name: "pages"
+        label: "Pages"
+        file: "content/pages.json"
         fields:
-          - { label: "Title", name: "title", widget: "string" }
-          - { label: "Body", name: "body", widget: "markdown" }
+          - label: "Pages"
+            name: "pages"
+            widget: "list"
+            fields:
+              - { label: "Title", name: "title", widget: "string" }
+              - { label: "Body", name: "body", widget: "markdown" }

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Cozy Critters Admin</title>
-    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/markdown-it@14.0.0/dist/markdown-it.min.js" defer></script>
   </head>
   <body>
     <div id="cms"></div>


### PR DESCRIPTION
## Summary
- copy public/admin into client/dist/admin during the build so the admin panel is deployed
- load markdown-it and defer Decap CMS script to avoid runtime errors
- restructure CMS collections using `files` entries to satisfy schema

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689be5f9cd2483218854c3dbb3a0a564