### PR TITLE
feat: add basic login page for CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Proof:
 - Currently Not Required — App works without a backend
 
 ### 📝 Content Management
-An optional [Decap CMS](https://decapcms.org/) interface lives at `/admin/` and edits JSON files in the `content/` directory via Git commits.
+An optional [Decap CMS](https://decapcms.org/) interface lives at `/admin/`. Sign in through `/cms-login.html` using credentials from `cms-users.json` to edit JSON files in the `content/` directory without relying on GitHub.
 
 ### ♿ Accessibility & Design
 - Radix UI foundation for ARIA and keyboard support

--- a/docs/cms-auth.md
+++ b/docs/cms-auth.md
@@ -1,62 +1,27 @@
 # CMS Authentication
 
-GitHub manages access to the Decap CMS admin area.
-For self‑hosted deployments, the server can also require HTTP Basic Auth
-before the CMS assets or APIs are served.
+The Cozy Critters CMS no longer relies on GitHub OAuth. Access is controlled with simple HTTP Basic Authentication.
 
-### Configuration
+## Configuration
 
-In `public/admin/config.yml` the backend is configured to use GitHub:
+The Decap CMS config (`public/admin/config.yml`) uses the `file-system` backend so content edits write directly to the server's file system.
 
 ```yml
 backend:
-  name: github
-  repo: owner/CozyCritters
+  name: file-system
+  api_root: /api
   branch: main
-  auth_type: implicit
 ```
 
-Only collaborators with write access to the repository can open the CMS.
+## Creating accounts
 
-## Basic Auth setup
+1. Run `npm run cms:add-user -- <username> <password>` to hash a password and append it to `cms-users.json`.
+2. Alternatively, set the `CMS_USERS` environment variable to a JSON object mapping usernames to `<salt>:<hash>` strings.
 
-1. **Create editor accounts**
-   - Run `npm run cms:add-user -- <username> <password>` to hash a password and
-     append it to `cms-users.json`.
-   - Alternatively, set the `CMS_USERS` environment variable to a JSON object
-     mapping usernames to `<salt>:<hash>` strings.
-2. **Protect CMS routes**
-   - The server automatically applies Basic Auth to `/admin`, `/api`, and
-     `/content` routes when credentials are present.
-3. **Log in**
-   - Open `/admin/` in the browser and enter the username and password when
-     prompted.
+## Login flow
 
-### Login flow
+1. Open `/cms-login.html` in your browser.
+2. Enter the provided username and password.
+3. On success the CMS admin interface loads and all subsequent API requests include the necessary credentials.
 
-1. Deploy the app or run the development server.
-2. Visit `/admin/` and choose **Log in with GitHub**.
-3. Authorize the application in the GitHub OAuth screen.
-4. After authentication, the CMS loads if your GitHub account has write access to the repository.
-
-### Inviting new editors
-
-1. In the GitHub repository, open **Settings → Collaborators and teams**.
-2. Click **Add people** and enter the editor's username or email.
-3. Grant the user write access and send the invitation.
-4. The recipient accepts the invitation to gain CMS access.
-
-### Account recovery
-
-- **Forgot password:** Use GitHub's password reset process.
-- **Lost or expired invite:** Send a new invitation from the repository settings on GitHub.
-- **Other login issues:** Review your GitHub account status or contact the repository owner.
-
-### Migrating from Netlify Identity
-
-Netlify Identity has been deprecated. If your project previously used it:
-
-1. In the Netlify dashboard, open the **Identity** tab.
-2. Select **Export users** to download a CSV of existing accounts.
-3. Notify users to authenticate with GitHub going forward.
-
+Share the credentials with editors who need access. To revoke access, remove the user entry from `cms-users.json` or rotate the password.

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,14 +1,7 @@
 backend:
-  name: github
-  ## The GitHub repository slug in the form "owner/repo".
-  ## Update this to match your project repository.
-  repo: CatgirlRika/CozyCritters
+  name: file-system
+  api_root: /api
   branch: main
-  ## Use Netlify to handle authentication.
-  base_url: https://api.netlify.com
-  auth_endpoint: auth
-  site_id: cozycritter
-  ## Access is restricted to GitHub collaborators with write permissions.
 publish_mode: editorial_workflow
 media_folder: "public/uploads"
 public_folder: "/uploads"

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -3,6 +3,21 @@
   <head>
     <meta charset="utf-8" />
     <title>Cozy Critters Admin</title>
+    <script>
+      const token = localStorage.getItem('cmsAuth');
+      if (token) {
+        const origFetch = window.fetch.bind(window);
+        window.fetch = (input, init = {}) => {
+          init.headers = init.headers || {};
+          if (init.headers instanceof Headers) {
+            init.headers.set('Authorization', 'Basic ' + token);
+          } else {
+            init.headers['Authorization'] = 'Basic ' + token;
+          }
+          return origFetch(input, init);
+        };
+      }
+    </script>
     <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/markdown-it@14.0.0/dist/markdown-it.min.js" defer></script>
   </head>

--- a/public/cms-login.html
+++ b/public/cms-login.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>CMS Login</title>
+    <style>
+      body { display: flex; align-items: center; justify-content: center; height: 100vh; font-family: sans-serif; }
+      form { display: flex; flex-direction: column; gap: 0.5rem; width: 300px; }
+      input { padding: 0.5rem; }
+      button { padding: 0.5rem; }
+    </style>
+  </head>
+  <body>
+    <form id="loginForm">
+      <input id="username" type="text" placeholder="Username" required />
+      <input id="password" type="password" placeholder="Password" required />
+      <button type="submit">Login</button>
+    </form>
+    <script>
+      const form = document.getElementById('loginForm');
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const username = (document.getElementById('username') as HTMLInputElement).value;
+        const password = (document.getElementById('password') as HTMLInputElement).value;
+        const token = btoa(`${username}:${password}`);
+        try {
+          const res = await fetch('/admin/index.html', { headers: { 'Authorization': 'Basic ' + token } });
+          if (!res.ok) throw new Error('Invalid credentials');
+          localStorage.setItem('cmsAuth', token);
+          const html = await res.text();
+          document.open();
+          document.write(html);
+          document.close();
+        } catch (err) {
+          alert('Login failed');
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace GitHub-based Decap CMS auth with filesystem backend
- add `/cms-login.html` and inject auth headers for CMS requests
- document new Basic Auth flow

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689c99f75af8832193df7ed7c3371ec1