### PR TITLE
feat: admin user management interface

### DIFF
--- a/client/src/components/admin/protected-route.tsx
+++ b/client/src/components/admin/protected-route.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from "react";
+import { LoadingPage } from "@/components/loading";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export function ProtectedRoute({ children }: Props) {
+  const [authorized, setAuthorized] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    fetch("/api/admin/users", { credentials: "include" })
+      .then((res) => {
+        if (res.ok) {
+          setAuthorized(true);
+        } else {
+          setAuthorized(false);
+        }
+      })
+      .catch(() => setAuthorized(false));
+  }, []);
+
+  if (authorized === null) {
+    return <LoadingPage />;
+  }
+
+  if (!authorized) {
+    window.location.href = "/cms-login.html";
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/client/src/components/admin/user-row.tsx
+++ b/client/src/components/admin/user-row.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from "react";
+import { TableRow, TableCell } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export interface CmsUser {
+  username: string;
+  role: string;
+}
+
+interface Props {
+  user: CmsUser;
+  onChanged: () => void;
+}
+
+export function UserRow({ user, onChanged }: Props) {
+  const [editing, setEditing] = useState(false);
+  const [role, setRole] = useState(user.role);
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const save = async () => {
+    setError(null);
+    setSuccess(null);
+    const res = await fetch(`/api/admin/users/${user.username}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        role,
+        ...(password ? { password } : {}),
+      }),
+    });
+    if (res.ok) {
+      setSuccess("Saved");
+      setEditing(false);
+      setPassword("");
+      onChanged();
+    } else {
+      const data = await res.json().catch(() => ({}));
+      setError(data.message || "Failed to update user");
+    }
+  };
+
+  const remove = async () => {
+    setError(null);
+    if (!window.confirm(`Delete ${user.username}?`)) return;
+    const res = await fetch(`/api/admin/users/${user.username}`, {
+      method: "DELETE",
+    });
+    if (res.ok) {
+      onChanged();
+    } else {
+      const data = await res.json().catch(() => ({}));
+      setError(data.message || "Failed to delete user");
+    }
+  };
+
+  if (editing) {
+    return (
+      <TableRow>
+        <TableCell className="font-mono">{user.username}</TableCell>
+        <TableCell>
+          <select
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+            className="border rounded px-2 py-1"
+          >
+            <option value="admin">admin</option>
+            <option value="mod">mod</option>
+            <option value="editor">editor</option>
+          </select>
+          <Input
+            type="password"
+            placeholder="New password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-2"
+          />
+          {error && <p className="text-red-600 text-sm mt-1">{error}</p>}
+          {success && <p className="text-green-600 text-sm mt-1">{success}</p>}
+        </TableCell>
+        <TableCell className="flex gap-2">
+          <Button type="button" onClick={save}>
+            Save
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => {
+              setEditing(false);
+              setRole(user.role);
+              setPassword("");
+              setError(null);
+              setSuccess(null);
+            }}
+          >
+            Cancel
+          </Button>
+        </TableCell>
+      </TableRow>
+    );
+  }
+
+  return (
+    <TableRow>
+      <TableCell className="font-mono">{user.username}</TableCell>
+      <TableCell>{user.role}</TableCell>
+      <TableCell className="flex gap-2">
+        <Button type="button" onClick={() => setEditing(true)}>
+          Edit
+        </Button>
+        <Button type="button" variant="destructive" onClick={remove}>
+          Delete
+        </Button>
+        {error && <p className="text-red-600 text-sm mt-1">{error}</p>}
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/client/src/pages/admin/users.tsx
+++ b/client/src/pages/admin/users.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from "react";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { UserRow, CmsUser } from "@/components/admin/user-row";
+
+export default function AdminUsers() {
+  const [users, setUsers] = useState<CmsUser[]>([]);
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [role, setRole] = useState("editor");
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const loadUsers = () => {
+    fetch("/api/admin/users", { credentials: "include" })
+      .then((res) => {
+        if (!res.ok) throw new Error();
+        return res.json();
+      })
+      .then(setUsers)
+      .catch(() => setError("Failed to load users"));
+  };
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setMessage(null);
+    const res = await fetch("/api/admin/users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username, password, role }),
+    });
+    if (res.ok) {
+      setMessage("User added");
+      setUsername("");
+      setPassword("");
+      setRole("editor");
+      loadUsers();
+    } else {
+      const data = await res.json().catch(() => ({}));
+      setError(data.message || "Failed to add user");
+    }
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold mb-4">CMS Users</h1>
+      {error && <p className="text-red-600 mb-4">{error}</p>}
+      {message && <p className="text-green-600 mb-4">{message}</p>}
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Username</TableHead>
+            <TableHead>Role</TableHead>
+            <TableHead className="w-[200px]">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {users.map((user) => (
+            <UserRow key={user.username} user={user} onChanged={loadUsers} />
+          ))}
+          {users.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={3} className="text-center">
+                No users
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+      <h2 className="text-xl font-semibold mt-6 mb-2">Add User</h2>
+      <form onSubmit={handleAdd} className="grid gap-2 max-w-md">
+        <div>
+          <Label htmlFor="username">Username</Label>
+          <Input
+            id="username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <Label htmlFor="role">Role</Label>
+          <select
+            id="role"
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+            className="border rounded w-full h-10 px-3"
+          >
+            <option value="admin">admin</option>
+            <option value="mod">mod</option>
+            <option value="editor">editor</option>
+          </select>
+        </div>
+        <Button type="submit" className="mt-2">
+          Add
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -2,10 +2,12 @@
 import React, { Suspense } from "react";
 import { Switch, Route } from "wouter";
 import { LoadingPage } from "@/components/loading";
+import { ProtectedRoute } from "@/components/admin/protected-route";
 
 const Home = React.lazy(() => import("@/pages/home"));
 const GamesPage = React.lazy(() => import("@/pages/games-page"));
 const ThemeCustomizer = React.lazy(() => import("@/pages/ThemeCustomizer"));
+const AdminUsers = React.lazy(() => import("@/pages/admin/users"));
 const NotFound = React.lazy(() => import("@/pages/not-found"));
 
 export default function AppRoutes() {
@@ -15,6 +17,14 @@ export default function AppRoutes() {
         <Route path="/" component={Home} />
         <Route path="/games" component={GamesPage} />
         <Route path="/settings/theme" component={ThemeCustomizer} />
+        <Route
+          path="/admin"
+          component={() => (
+            <ProtectedRoute>
+              <AdminUsers />
+            </ProtectedRoute>
+          )}
+        />
         <Route component={NotFound} />
       </Switch>
     </Suspense>


### PR DESCRIPTION
## Summary
- add admin user management page with forms to add, edit, delete and reset passwords
- protect `/admin` route and redirect to login when unauthenticated
- integrate client with `/api/admin/users` endpoints

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689ca4bc82a883218be4dac0586d466a