### PR TITLE
feat: move client build to dist/public

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "npm run dev:web",
     "dev:web": "vite",
     "dev:server": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && cp -r public/admin client/dist/admin && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && cp -r public/admin client/dist/admin && mkdir -p dist/public && cp -r client/dist/* dist/public && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "preview": "vite preview",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",


### PR DESCRIPTION
## Summary
- copy Vite build output into `dist/public` so server and client artifacts share a common build directory

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cd191d0ec8321a642480691df975e