### PR TITLE
Use cookie library for CMS authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "cookie": "^0.7.1",
         "cors": "^2.8.5",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "cookie": "^0.7.1",
     "cors": "^2.8.5",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.6.0",

--- a/server/middleware/cms-auth.ts
+++ b/server/middleware/cms-auth.ts
@@ -1,5 +1,6 @@
 import { type Request, type Response, type NextFunction } from "express";
 import crypto from "crypto";
+import cookie from "cookie";
 import { getUser } from "../admin-users";
 
 const JWT_SECRET = process.env.JWT_SECRET || "change-me";
@@ -40,14 +41,9 @@ export function cmsAuth(req: Request, res: Response, next: NextFunction): void {
 
   if (header?.startsWith("Bearer ")) {
     token = header.substring(7);
-  } else if (req.headers.cookie) {
-    const match = req.headers.cookie
-      .split(";")
-      .map((c) => c.trim())
-      .find((c) => c.startsWith("token="));
-    if (match) {
-      token = match.split("=")[1];
-    }
+  } else {
+    const cookies = cookie.parse(req.headers.cookie ?? "");
+    token = cookies.token;
   }
 
   if (!token) {


### PR DESCRIPTION
## Summary
- add `cookie` dependency for centralized cookie parsing
- use `cookie.parse` in CMS auth middleware and read token from parsed cookies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd5883d1c8321ae14b46dc009f733