### PR TITLE
feat: add support page and route

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -110,6 +110,12 @@ export default function Home() {
           <span role="img" aria-label="green heart">💚</span> All your data stays private on your device
         </p>
         <p>Made with love for your wellbeing and neurodivergent minds</p>
+        <p className="mt-2">
+          Need help?{' '}
+          <a href="/support" className="underline">
+            Visit Support
+          </a>
+        </p>
       </footer>
     </div>
   );

--- a/client/src/pages/support.tsx
+++ b/client/src/pages/support.tsx
@@ -1,0 +1,16 @@
+import { Card, CardContent } from "@/components/ui/card";
+
+export default function Support() {
+  return (
+    <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
+      <Card className="w-full max-w-md mx-4">
+        <CardContent className="pt-6 space-y-4">
+          <h1 className="text-2xl font-bold">Support</h1>
+          <p>📧 Email: support@example.com</p>
+          <p>❓ FAQ: Coming soon...</p>
+          <p>💬 More help resources on the way.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -8,6 +8,7 @@ const Home = React.lazy(() => import("@/pages/home"));
 const GamesPage = React.lazy(() => import("@/pages/games-page"));
 const ThemeCustomizer = React.lazy(() => import("@/pages/ThemeCustomizer"));
 const AdminUsers = React.lazy(() => import("@/pages/admin/users"));
+const Support = React.lazy(() => import("@/pages/support"));
 const NotFound = React.lazy(() => import("@/pages/not-found"));
 
 export default function AppRoutes() {
@@ -25,6 +26,7 @@ export default function AppRoutes() {
             </ProtectedRoute>
           )}
         />
+        <Route path="/support" component={Support} />
         <Route component={NotFound} />
       </Switch>
     </Suspense>


### PR DESCRIPTION
## Summary
- add Support page with contact placeholders
- register /support route and link from home page

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689d26bc54488321820607ae6b68a592