### PR TITLE
feat: add support page and route

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -26,7 +26,13 @@ export default function Home() {
       <a href="#main-content" className="skip-link">Skip to main content</a>
       {/* Header */}
       <header role="banner" className="bg-primary text-primary-foreground p-6 rounded-b-3xl shadow-md relative">
-        <div className="absolute top-4 right-4">
+        <div className="absolute top-4 right-4 flex items-center space-x-2">
+          <a
+            href="/support"
+            className="text-sm underline focus:outline-none focus:ring-2 focus:ring-white focus:ring-opacity-50"
+          >
+            Support
+          </a>
           <ThemeToggle />
         </div>
         <div className="text-center">

--- a/client/src/pages/support.tsx
+++ b/client/src/pages/support.tsx
@@ -1,0 +1,54 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ThemeToggle } from "@/components/theme-toggle";
+
+export default function Support() {
+  return (
+    <div className="min-h-screen max-w-md mx-auto bg-background shadow-lg relative">
+      <a href="#main-content" className="skip-link">
+        Skip to main content
+      </a>
+      <header
+        role="banner"
+        className="bg-primary text-primary-foreground p-6 rounded-b-3xl shadow-md relative"
+      >
+        <div className="absolute top-4 right-4">
+          <ThemeToggle />
+        </div>
+        <h1 className="text-2xl font-bold text-center">Support</h1>
+      </header>
+      <main id="main-content" role="main" className="p-6">
+        <Card aria-labelledby="support-heading">
+          <CardHeader>
+            <CardTitle id="support-heading">How can we help?</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p>
+              <span role="img" aria-label="email">
+                📧
+              </span>{" "}
+              Email: <a href="mailto:support@example.com" className="underline">support@example.com</a>
+            </p>
+            <p>
+              <span role="img" aria-label="question mark">
+                ❓
+              </span>{" "}
+              FAQ: Coming soon...
+            </p>
+            <p>
+              <span role="img" aria-label="speech balloon">
+                💬
+              </span>{" "}
+              More help resources on the way.
+            </p>
+          </CardContent>
+        </Card>
+        <p className="mt-4 text-center">
+          <a href="/" className="underline">
+            ← Back to Home
+          </a>
+        </p>
+      </main>
+    </div>
+  );
+}
+

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -8,6 +8,7 @@ const Home = React.lazy(() => import("@/pages/home"));
 const GamesPage = React.lazy(() => import("@/pages/games-page"));
 const ThemeCustomizer = React.lazy(() => import("@/pages/ThemeCustomizer"));
 const AdminUsers = React.lazy(() => import("@/pages/admin/users"));
+const Support = React.lazy(() => import("@/pages/support"));
 const NotFound = React.lazy(() => import("@/pages/not-found"));
 
 export default function AppRoutes() {
@@ -25,6 +26,7 @@ export default function AppRoutes() {
             </ProtectedRoute>
           )}
         />
+        <Route path="/support" component={Support} />
         <Route component={NotFound} />
       </Switch>
     </Suspense>


### PR DESCRIPTION
## Summary
- add Support page with contact placeholders
- register /support route and link from home page
- surface Support link in header and align Support page with app layout for accessibility

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689d26bc54488321820607ae6b68a592