### PR TITLE
fix: remove duplicate default export from support page

### DIFF
--- a/client/src/pages/support.tsx
+++ b/client/src/pages/support.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent } from "@/components/ui/card";
 
-export default function Support() {
+const Support = () => {
   return (
     <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
       <Card className="w-full max-w-md mx-4">
@@ -13,4 +13,6 @@ export default function Support() {
       </Card>
     </div>
   );
-}
+};
+
+export default Support;


### PR DESCRIPTION
## Summary
- ensure Support page has a single default export

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689d2aafa0b483219e06200290eb481d