### PR TITLE
Fix admin login script to run on Netlify

### DIFF
--- a/public/cms-login.html
+++ b/public/cms-login.html
@@ -20,8 +20,8 @@
       const form = document.getElementById('loginForm');
       form.addEventListener('submit', async (e) => {
         e.preventDefault();
-        const username = (document.getElementById('username') as HTMLInputElement).value;
-        const password = (document.getElementById('password') as HTMLInputElement).value;
+        const username = document.getElementById('username').value;
+        const password = document.getElementById('password').value;
         const token = btoa(`${username}:${password}`);
         try {
           const res = await fetch('/admin/index.html', { headers: { 'Authorization': 'Basic ' + token } });


### PR DESCRIPTION
## Summary
- convert `cms-login.html` script to plain JavaScript so it runs in the browser without a build step

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d5c760d708321857f402d1e1f9727