### PR TITLE
chore: use env for auth backend redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,22 +7,22 @@
   NODE_VERSION = "18"
 
 # Proxy CMS requests to an external Node server
-# Replace `https://cms.example.com` with your server's URL
+# Set `AUTH_BACKEND_URL` in Netlify to your server's URL
 [[redirects]]
   from = "/api/*"
-  to = "https://cms.example.com/api/:splat"
+  to = "${AUTH_BACKEND_URL}/api/:splat"
   status = 200
   force = true
 
 [[redirects]]
   from = "/admin/*"
-  to = "https://cms.example.com/admin/:splat"
+  to = "${AUTH_BACKEND_URL}/admin/:splat"
   status = 200
   force = true
 
 [[redirects]]
   from = "/content/*"
-  to = "https://cms.example.com/content/:splat"
+  to = "${AUTH_BACKEND_URL}/content/:splat"
   status = 200
   force = true
 


### PR DESCRIPTION
## Summary
- use `AUTH_BACKEND_URL` env var for Netlify redirect targets
- update comments to document the variable

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689d60e6e7c48321b5cdf27631a6679c