### PR TITLE
docs: clarify content removal policy

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -45,7 +45,7 @@ or harmful.
 
 Community leaders have the right and responsibility to remove, edit, or reject
 comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
+not aligned to this Code of Conduct, and will communicate the reasons for their
 decisions when appropriate.
 
 ## Scope


### PR DESCRIPTION
## Summary
- reword removal policy in Code of Conduct to remove mod-centric terminology

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689def0bc33c8321a214efa8ce76b028