### PR TITLE
docs: welcome neurodiverse communication

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,13 +4,14 @@
 
 We as members, contributors, and leaders of the Cozy Critter project pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+size, visible or invisible disability, neurodivergence, communication style,
+ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+diverse, inclusive, and healthy community that embraces neurodiversity and a
+range of communication styles.
 
 ## Our Standards
 
@@ -24,6 +25,11 @@ community include:
   and learning from the experience
 * Focusing on what is best not just for us as individuals, but for the
   overall community
+* Allowing direct, literal communication without assuming rudeness
+* Being mindful of sensory and accessibility needs, such as providing content
+  warnings or allowing camera-off participation
+* Asking for clarification when communication is unclear before assuming
+  malicious intent
 
 Examples of unacceptable behavior include:
 


### PR DESCRIPTION
## Summary
- embrace neurodivergent people and communication styles in Our Pledge
- add examples for direct communication and sensory needs in Our Standards
- encourage clarifying questions before assuming malicious intent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689df45258b08321aafcb8836234436a