### PR TITLE
feat: add mood manager and customization guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Everything stays on your device because your emotional data is deeply personal.
 - [🏢 For Organizations](#-for-autism--neurodivergent-support-organizations)
 - [🛠️ Technical Details](#-tech--architecture)
 - [📚 Full Docs](docs/README.md)
+- [🎨 Mood Customization](docs/mood-customization.md)
 - [📝 Content Management](#-content-management)
 
 ---

--- a/client/src/components/mood-manager.tsx
+++ b/client/src/components/mood-manager.tsx
@@ -1,0 +1,156 @@
+import { useState, useEffect } from "react";
+import { fetchMoods, MoodOption } from "@/lib/content";
+
+interface MoodManagerProps {
+  onBack: () => void;
+}
+
+const CUSTOM_MOODS_KEY = "cozy-critter-custom-moods";
+const HIDDEN_MOODS_KEY = "cozy-critter-hidden-moods";
+
+function getLocalArray<T>(key: string): T[] {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveLocalArray<T>(key: string, value: T[]): void {
+  localStorage.setItem(key, JSON.stringify(value));
+}
+
+export function MoodManager({ onBack }: MoodManagerProps) {
+  const [moods, setMoods] = useState<MoodOption[]>([]);
+  const [emoji, setEmoji] = useState("");
+  const [name, setName] = useState("");
+  const [color, setColor] = useState("");
+
+  useEffect(() => {
+    loadMoods();
+  }, []);
+
+  const loadMoods = async () => {
+    try {
+      const list = await fetchMoods();
+      setMoods(list);
+    } catch {
+      setMoods([]);
+    }
+  };
+
+  const handleAddMood = () => {
+    if (!emoji.trim() || !name.trim() || !color.trim()) return;
+    const custom = getLocalArray<MoodOption>(CUSTOM_MOODS_KEY);
+    const newMood = { emoji: emoji.trim(), mood: name.trim(), color: color.trim() };
+    saveLocalArray(CUSTOM_MOODS_KEY, [...custom, newMood]);
+    setEmoji("");
+    setName("");
+    setColor("");
+    loadMoods();
+  };
+
+  const handleRemoveMood = (mood: MoodOption) => {
+    const custom = getLocalArray<MoodOption>(CUSTOM_MOODS_KEY);
+    if (custom.find(m => m.mood === mood.mood)) {
+      saveLocalArray(
+        CUSTOM_MOODS_KEY,
+        custom.filter(m => m.mood !== mood.mood)
+      );
+    } else {
+      const hidden = getLocalArray<string>(HIDDEN_MOODS_KEY);
+      if (!hidden.includes(mood.mood)) {
+        saveLocalArray(HIDDEN_MOODS_KEY, [...hidden, mood.mood]);
+      }
+    }
+    loadMoods();
+  };
+
+  return (
+    <main className="p-6 bg-background dark:bg-background">
+      <div className="max-w-2xl mx-auto">
+        <div className="flex items-center mb-6">
+          <button
+            onClick={onBack}
+            className="mr-3 p-2 text-muted-foreground hover:text-foreground transition-colors focus:outline-none focus:ring-2 focus:ring-primary/50 rounded"
+            aria-label="Go back"
+          >
+            ←
+          </button>
+          <h2 className="text-2xl font-semibold text-brown dark:text-brown">
+            Manage Moods
+          </h2>
+        </div>
+
+        <div className="bg-card dark:bg-card border border-border dark:border-border rounded-xl p-4 mb-6">
+          <div className="grid gap-4" aria-label="Add mood form">
+            <div>
+              <label htmlFor="mood-emoji" className="block text-sm font-medium text-brown dark:text-brown mb-1">
+                Emoji
+              </label>
+              <input
+                id="mood-emoji"
+                value={emoji}
+                onChange={e => setEmoji(e.target.value)}
+                className="w-full p-2 border border-border dark:border-border rounded bg-background text-foreground"
+              />
+            </div>
+            <div>
+              <label htmlFor="mood-name" className="block text-sm font-medium text-brown dark:text-brown mb-1">
+                Name
+              </label>
+              <input
+                id="mood-name"
+                value={name}
+                onChange={e => setName(e.target.value)}
+                className="w-full p-2 border border-border dark:border-border rounded bg-background text-foreground"
+              />
+            </div>
+            <div>
+              <label htmlFor="mood-color" className="block text-sm font-medium text-brown dark:text-brown mb-1">
+                Color class
+              </label>
+              <input
+                id="mood-color"
+                value={color}
+                onChange={e => setColor(e.target.value)}
+                placeholder="bg-green-600 text-white"
+                className="w-full p-2 border border-border dark:border-border rounded bg-background text-foreground"
+              />
+            </div>
+            <button
+              onClick={handleAddMood}
+              className="px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/50"
+            >
+              Add mood
+            </button>
+          </div>
+        </div>
+
+        <ul className="space-y-3" aria-label="Existing moods">
+          {moods.map(m => (
+            <li
+              key={m.mood}
+              className="flex items-center justify-between bg-card dark:bg-card border border-border dark:border-border rounded-lg p-3"
+            >
+              <span className="flex items-center gap-2">
+                <span className="text-2xl" aria-hidden="true">{m.emoji}</span>
+                <span>{m.mood}</span>
+              </span>
+              <button
+                onClick={() => handleRemoveMood(m)}
+                className="px-2 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-400"
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </main>
+  );
+}
+

--- a/client/src/lib/content.ts
+++ b/client/src/lib/content.ts
@@ -15,12 +15,31 @@ export interface PageEntry {
   body: string;
 }
 
+const CUSTOM_MOODS_KEY = "cozy-critter-custom-moods";
+const HIDDEN_MOODS_KEY = "cozy-critter-hidden-moods";
+
 async function fetchJson<T>(path: string): Promise<T> {
   const res = await fetch(path);
   if (!res.ok) throw new Error(`Failed to load ${path}`);
   return res.json();
 }
 
-export const fetchMoods = () => fetchJson<MoodOption[]>("/content/moods.json");
+function getLocalArray<T>(key: string): T[] {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export const fetchMoods = async (): Promise<MoodOption[]> => {
+  const defaults = await fetchJson<MoodOption[]>("/content/moods.json");
+  const custom = getLocalArray<MoodOption>(CUSTOM_MOODS_KEY);
+  const hidden = getLocalArray<string>(HIDDEN_MOODS_KEY);
+  return [...defaults, ...custom].filter(m => !hidden.includes(m.mood));
+};
 export const fetchGames = () => fetchJson<GameEntry[]>("/content/games.json");
 export const fetchPages = () => fetchJson<PageEntry[]>("/content/pages.json");

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -5,9 +5,9 @@ import { MiniGamesPreview } from "@/components/mini-games-preview";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { CustomMessages } from "@/components/custom-messages";
 import { PrivacySettings } from "@/components/privacy-settings";
-import { moodStorage } from "@/lib/mood-storage";
+import { MoodManager } from "@/components/mood-manager";
 
-type View = "checkIn" | "moodLog" | "customMessages" | "privacy";
+type View = "checkIn" | "moodLog" | "customMessages" | "moodManager" | "privacy";
 
 export default function Home() {
   const [currentView, setCurrentView] = useState<View>("checkIn");
@@ -73,6 +73,17 @@ export default function Home() {
             Messages
           </button>
           <button
+            onClick={() => setCurrentView("moodManager")}
+            aria-pressed={currentView === "moodManager"}
+            className={`px-3 py-2 rounded-full text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-white focus:ring-opacity-50 ${
+              currentView === "moodManager"
+                ? "bg-white bg-opacity-20"
+                : "hover:bg-white hover:bg-opacity-10"
+            }`}
+          >
+            Moods
+          </button>
+          <button
             onClick={() => setCurrentView("privacy")}
             aria-pressed={currentView === "privacy"}
             className={`px-3 py-2 rounded-full text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-white focus:ring-opacity-50 ${
@@ -99,6 +110,8 @@ export default function Home() {
           <MoodGarden onStartCheckIn={handleStartCheckIn} />
         ) : currentView === "customMessages" ? (
           <CustomMessages onBack={() => setCurrentView("checkIn")} />
+        ) : currentView === "moodManager" ? (
+          <MoodManager onBack={() => setCurrentView("checkIn")} />
         ) : (
           <PrivacySettings onBack={() => setCurrentView("checkIn")} />
         )}

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Quick links
 - Deployment guide: ./deployment-guide.md
 - Privacy & security verification: ./privacy-security.md
 - Accessibility notes: ./accessibility.md
+- Mood customization: ./mood-customization.md
 - Backup & export: ./backup-export.md
 - FAQ: ./faq.md
 - Contributing: ./contributing.md

--- a/docs/mood-customization.md
+++ b/docs/mood-customization.md
@@ -1,0 +1,24 @@
+# Mood and Color Customization
+
+Cozy Critter lets you tailor mood options to match how **you** experience feelings. This guide offers a sensory-friendly way to adjust moods and their colors without editing files.
+
+## Open the Mood Manager
+1. From the home screen, choose **Moods**.
+2. The manager lists every mood currently available.
+
+## Add a Mood
+1. Enter an emoji that represents the feeling.
+2. Give the mood a short name.
+3. Provide a Tailwind CSS color class (for high‑contrast, try `bg-green-600 text-white`).
+4. Select **Add mood**. Your new mood appears immediately.
+
+## Remove a Mood
+- Select **Remove** next to a mood you no longer want.
+- Built‑in moods are hidden instead of deleted so you can restore them later by clearing the hidden list.
+
+## Accessibility Tips
+- All fields have clear labels and can be reached with the keyboard.
+- Use high‑contrast colors for better readability.
+- Custom moods are stored only in your browser’s `localStorage`. Clearing site data resets them.
+
+Need more help? Visit the [FAQ](faq.md).


### PR DESCRIPTION
## Summary
- document mood and color customization
- allow users to add or hide moods in-app
- link mood manager from home screen navigation

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689dfe486e8c8321a5db7b6ddbc9e989