### PR TITLE
fix: handle missing content directory during build

### DIFF
--- a/scripts/copy-content.js
+++ b/scripts/copy-content.js
@@ -1,7 +1,11 @@
-import { cpSync } from 'fs';
+import { cpSync, existsSync } from 'fs';
 import { resolve } from 'path';
 
-const src = resolve('content');
+const src = resolve('client', 'public', 'content');
 const dest = resolve('client', 'dist', 'content');
 
-cpSync(src, dest, { recursive: true });
+if (existsSync(src)) {
+  cpSync(src, dest, { recursive: true });
+} else {
+  console.warn(`Source content directory not found at ${src}. Skipping copy.`);
+}


### PR DESCRIPTION
## Summary
- handle missing `content` directory in build script

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dff241d648321b5b855f97eea4842