### PR TITLE
feat: add offline fallback for mood manager

### DIFF
--- a/client/src/lib/content.ts
+++ b/client/src/lib/content.ts
@@ -18,6 +18,18 @@ export interface PageEntry {
 const CUSTOM_MOODS_KEY = "cozy-critter-custom-moods";
 const HIDDEN_MOODS_KEY = "cozy-critter-hidden-moods";
 
+// Default moods bundled with the app for offline use
+const FALLBACK_MOODS: MoodOption[] = [
+  { emoji: "🐻", mood: "Happy", color: "bg-secondary-custom" },
+  { emoji: "🦊", mood: "Calm", color: "bg-calm-custom bg-opacity-30" },
+  { emoji: "🐢", mood: "Tired", color: "bg-purple-100" },
+  { emoji: "🦦", mood: "Anxious", color: "bg-orange-100" },
+  { emoji: "🐰", mood: "Excited", color: "bg-pink-100" },
+  { emoji: "🦋", mood: "Peaceful", color: "bg-green-100" },
+  { emoji: "🦔", mood: "Overwhelmed", color: "bg-red-100" },
+  { emoji: "🐨", mood: "Content", color: "bg-content-custom" },
+];
+
 async function fetchJson<T>(path: string): Promise<T> {
   const res = await fetch(path);
   if (!res.ok) throw new Error(`Failed to load ${path}`);
@@ -36,7 +48,12 @@ function getLocalArray<T>(key: string): T[] {
 }
 
 export const fetchMoods = async (): Promise<MoodOption[]> => {
-  const defaults = await fetchJson<MoodOption[]>("/content/moods.json");
+  let defaults: MoodOption[] = [];
+  try {
+    defaults = await fetchJson<MoodOption[]>("/content/moods.json");
+  } catch {
+    defaults = FALLBACK_MOODS;
+  }
   const custom = getLocalArray<MoodOption>(CUSTOM_MOODS_KEY);
   const hidden = getLocalArray<string>(HIDDEN_MOODS_KEY);
   return [...defaults, ...custom].filter(m => !hidden.includes(m.mood));


### PR DESCRIPTION
## Summary
- ensure mood manager loads default moods even if fetch fails by bundling fallback list

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e0276a0288321af21499ebd168e5a