### PR TITLE
refactor: modularize theme customizer

### DIFF
--- a/client/src/components/theme/ColorPicker.tsx
+++ b/client/src/components/theme/ColorPicker.tsx
@@ -1,0 +1,45 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface ColorPickerProps {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  helpText?: string;
+}
+
+/**
+ * ColorPicker allows choosing a color using an accessible input.
+ * Helpful instructions can be provided via `helpText` which is
+ * connected to the input for screen readers and users who benefit
+ * from clear guidance.
+ */
+export function ColorPicker({
+  id,
+  label,
+  value,
+  onChange,
+  helpText,
+}: ColorPickerProps) {
+  const helpId = helpText ? `${id}-help` : undefined;
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        type="color"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label={label}
+        aria-describedby={helpId}
+      />
+      {helpText && (
+        <p id={helpId} className="text-sm text-muted-foreground">
+          {helpText}
+        </p>
+      )}
+    </div>
+  );
+}
+

--- a/client/src/components/theme/FontSelector.tsx
+++ b/client/src/components/theme/FontSelector.tsx
@@ -1,0 +1,61 @@
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface FontOption {
+  label: string;
+  value: string;
+}
+
+interface FontSelectorProps {
+  id?: string;
+  label: string;
+  value: string;
+  options: FontOption[];
+  onChange: (value: string) => void;
+  helpText?: string;
+}
+
+/**
+ * FontSelector renders a list of font options. The optional `helpText`
+ * is read by screen readers and presented visually to provide clear
+ * direction for neurodivergent users.
+ */
+export function FontSelector({
+  id = "font-selector",
+  label,
+  value,
+  options,
+  onChange,
+  helpText,
+}: FontSelectorProps) {
+  const helpId = helpText ? `${id}-help` : undefined;
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Select value={value} onValueChange={onChange}>
+        <SelectTrigger id={id} aria-label={label} aria-describedby={helpId}>
+          <SelectValue placeholder="Select font" />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((f) => (
+            <SelectItem key={f.value} value={f.value}>
+              {f.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {helpText && (
+        <p id={helpId} className="text-sm text-muted-foreground">
+          {helpText}
+        </p>
+      )}
+    </div>
+  );
+}
+

--- a/client/src/components/theme/ResetButton.tsx
+++ b/client/src/components/theme/ResetButton.tsx
@@ -1,0 +1,34 @@
+import { Button } from "@/components/ui/button";
+
+interface ResetButtonProps {
+  label: string;
+  onReset: () => void;
+  helpText?: string;
+}
+
+/**
+ * ResetButton resets theme selections. Clear messaging helps users
+ * understand the action before they commit to it.
+ */
+export function ResetButton({ label, onReset, helpText }: ResetButtonProps) {
+  const helpId = helpText ? `reset-help` : undefined;
+  return (
+    <div className="pt-2 space-y-2">
+      <Button
+        type="button"
+        variant="outline"
+        onClick={onReset}
+        aria-label={label}
+        aria-describedby={helpId}
+      >
+        {label}
+      </Button>
+      {helpText && (
+        <p id={helpId} className="text-sm text-muted-foreground">
+          {helpText}
+        </p>
+      )}
+    </div>
+  );
+}
+

--- a/client/src/components/theme/index.ts
+++ b/client/src/components/theme/index.ts
@@ -1,0 +1,4 @@
+export { ColorPicker } from "./ColorPicker";
+export { FontSelector } from "./FontSelector";
+export { ResetButton } from "./ResetButton";
+

--- a/client/src/pages/ThemeCustomizer.tsx
+++ b/client/src/pages/ThemeCustomizer.tsx
@@ -1,14 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import type { RouteComponentProps } from "wouter";
+import { ColorPicker, FontSelector, ResetButton } from "@/components/theme";
 
 interface ThemeSettings {
   primary: string;
@@ -50,7 +42,19 @@ function cssVarToHex(value: string) {
   return "#000000";
 }
 
-export default function ThemeCustomizer() {
+interface ThemeCustomizerProps extends RouteComponentProps {
+  labels?: Partial<
+    Record<"primary" | "secondary" | "accent" | "font" | "reset", string>
+  >;
+  helpText?: Partial<
+    Record<"primary" | "secondary" | "accent" | "font" | "reset", string>
+  >;
+}
+
+export default function ThemeCustomizer({
+  labels = {},
+  helpText = {},
+}: ThemeCustomizerProps) {
   const [settings, setSettings] = useState<ThemeSettings | null>(null);
   const [defaults, setDefaults] = useState<ThemeSettings | null>(null);
 
@@ -116,6 +120,24 @@ export default function ThemeCustomizer() {
     { label: "Courier New", value: "'Courier New', monospace" },
   ];
 
+  const label = {
+    primary: "Primary Color",
+    secondary: "Secondary Color",
+    accent: "Accent Color",
+    font: "Font",
+    reset: "Reset to default",
+    ...labels,
+  };
+
+  const help = {
+    primary: "Select the main color used throughout the app.",
+    secondary: "Pick a secondary color for subtle elements.",
+    accent: "Choose an accent color for highlights.",
+    font: "Choose a font. Options are previewed instantly.",
+    reset: "Revert all changes back to the original theme.",
+    ...helpText,
+  };
+
   return (
     <div className="p-6 space-y-6 max-w-md mx-auto">
       <h2 className="text-2xl font-bold">Theme Customizer</h2>
@@ -125,57 +147,41 @@ export default function ThemeCustomizer() {
           e.preventDefault();
         }}
       >
-        <div className="space-y-2">
-          <Label htmlFor="primary">Primary Color</Label>
-          <Input
-            id="primary"
-            type="color"
-            value={settings.primary}
-            onChange={(e) => updateSetting("primary", e.target.value)}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="secondary">Secondary Color</Label>
-          <Input
-            id="secondary"
-            type="color"
-            value={settings.secondary}
-            onChange={(e) => updateSetting("secondary", e.target.value)}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="accent">Accent Color</Label>
-          <Input
-            id="accent"
-            type="color"
-            value={settings.accent}
-            onChange={(e) => updateSetting("accent", e.target.value)}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label>Font</Label>
-          <Select
-            value={settings.font}
-            onValueChange={(v) => updateSetting("font", v)}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Select font" />
-            </SelectTrigger>
-            <SelectContent>
-              {fontOptions.map((f) => (
-                <SelectItem key={f.value} value={f.value}>
-                  {f.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="pt-2">
-          <Button type="button" variant="outline" onClick={reset}>
-            Reset to default
-          </Button>
-        </div>
+        <ColorPicker
+          id="primary"
+          label={label.primary}
+          value={settings.primary}
+          onChange={(v) => updateSetting("primary", v)}
+          helpText={help.primary}
+        />
+        <ColorPicker
+          id="secondary"
+          label={label.secondary}
+          value={settings.secondary}
+          onChange={(v) => updateSetting("secondary", v)}
+          helpText={help.secondary}
+        />
+        <ColorPicker
+          id="accent"
+          label={label.accent}
+          value={settings.accent}
+          onChange={(v) => updateSetting("accent", v)}
+          helpText={help.accent}
+        />
+        <FontSelector
+          label={label.font}
+          value={settings.font}
+          options={fontOptions}
+          onChange={(v) => updateSetting("font", v)}
+          helpText={help.font}
+        />
+        <ResetButton
+          label={label.reset}
+          onReset={reset}
+          helpText={help.reset}
+        />
       </form>
     </div>
   );
 }
+

--- a/docs/theme-customization.md
+++ b/docs/theme-customization.md
@@ -1,0 +1,39 @@
+# Theme customization components
+
+The theme customization UI has been modularized into reusable pieces under `client/src/components/theme/`.
+
+## Components
+
+### `ColorPicker`
+An accessible color input that announces optional help text for screen readers. Use it to select primary, secondary, or accent colors.
+
+```
+<ColorPicker
+  id="primary"
+  label="Primary Color"
+  value={color}
+  onChange={setColor}
+  helpText="Pick a color. Hex values are accepted."
+/>
+```
+
+### `FontSelector`
+Dropdown selector for fonts with ARIA labels and descriptions. Options are provided as `{ label, value }` pairs.
+
+### `ResetButton`
+Simple button that reverts theme settings. Helpful when users feel overwhelmed by changes.
+
+Each component accepts `helpText` props which are linked via `aria-describedby` to provide clear guidance, supporting neurodivergent users.
+
+## Importing
+
+All components can be imported from the folder index:
+
+```
+import { ColorPicker, FontSelector, ResetButton } from "@/components/theme";
+```
+
+## Page usage
+
+`ThemeCustomizer` composes these pieces and exposes `labels` and `helpText` props to override default messaging.
+


### PR DESCRIPTION
## Summary
- modularize theme customization into ColorPicker, FontSelector and ResetButton
- refactor ThemeCustomizer to compose modular components with customizable labels and help text
- document modular theme components and exports

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e024774348321984e85ce8ef918c1