### PR TITLE
feat: add async game loading

### DIFF
--- a/client/src/lib/game-registry.ts
+++ b/client/src/lib/game-registry.ts
@@ -7,6 +7,15 @@ class GameRegistry {
     this.games.set(game.config.id, game);
   }
 
+  async getComponent(id: string) {
+    const game = this.games.get(id);
+    if (!game) return undefined;
+    if (!game.Component) {
+      game.Component = await game.loader();
+    }
+    return game.Component;
+  }
+
   getGame(id: string): Game | undefined {
     return this.games.get(id);
   }

--- a/client/src/lib/games.ts
+++ b/client/src/lib/games.ts
@@ -1,9 +1,4 @@
 import { gameRegistry } from './game-registry';
-import { BreathingBubble } from '@/games/breathing-bubble';
-import { ColorPattern } from '@/games/color-pattern';
-import { DrawingPad } from '@/games/drawing-pad';
-import { ShapeMatch } from '@/games/shape-match';
-import { ZenBlocks } from '@/games/zen-blocks';
 
 // Register all games
 gameRegistry.register({
@@ -22,7 +17,7 @@ gameRegistry.register({
     },
     tags: ['breathing', 'meditation', 'anxiety', 'calming', 'mindfulness']
   },
-  Component: BreathingBubble
+  loader: () => import('@/games/breathing-bubble').then(m => m.BreathingBubble)
 });
 
 gameRegistry.register({
@@ -41,7 +36,7 @@ gameRegistry.register({
     },
     tags: ['memory', 'focus', 'patterns', 'colors', 'concentration']
   },
-  Component: ColorPattern
+  loader: () => import('@/games/color-pattern').then(m => m.ColorPattern)
 });
 
 gameRegistry.register({
@@ -60,7 +55,7 @@ gameRegistry.register({
     },
     tags: ['memory', 'matching', 'shapes', 'focus']
   },
-  Component: ShapeMatch
+  loader: () => import('@/games/shape-match').then(m => m.ShapeMatch)
 });
 
 gameRegistry.register({
@@ -79,8 +74,8 @@ gameRegistry.register({
     },
     tags: ['drawing', 'art', 'creative', 'expression']
   },
-    Component: DrawingPad
-  });
+  loader: () => import('@/games/drawing-pad').then(m => m.DrawingPad)
+});
 
 gameRegistry.register({
   config: {
@@ -98,7 +93,7 @@ gameRegistry.register({
     },
     tags: ['blocks', 'calming', 'focus', 'tetris']
   },
-  Component: ZenBlocks
+  loader: () => import('@/games/zen-blocks').then(m => m.ZenBlocks)
 });
 
 // Export the registry for use in components

--- a/client/src/pages/mini-games.tsx
+++ b/client/src/pages/mini-games.tsx
@@ -103,7 +103,7 @@ export default function MiniGames({ onBack }: MiniGamesProps) {
     let active = true;
     if (currentGame) {
       gameRegistry.getComponent(currentGame.config.id).then((comp) => {
-        if (active) setGameComponent(() => comp || null);
+        if (active) setGameComponent(comp || null);
       });
     } else {
       setGameComponent(null);

--- a/client/src/pages/mini-games.tsx
+++ b/client/src/pages/mini-games.tsx
@@ -115,7 +115,16 @@ export default function MiniGames({ onBack }: MiniGamesProps) {
 
   if (currentGame) {
     if (!GameComponent) {
-      return <div className="p-6" />;
+      return (
+        <div
+          className="p-6 flex items-center justify-center"
+          aria-label="Loading game"
+          role="status"
+        >
+          <span className="animate-spin mr-2" aria-hidden="true">⏳</span>
+          <span>Loading game...</span>
+        </div>
+      );
     }
     const LoadedComponent = GameComponent;
     return (

--- a/client/src/types/game.ts
+++ b/client/src/types/game.ts
@@ -39,5 +39,6 @@ export interface GameResult {
 
 export interface Game {
   config: GameConfig;
-  Component: React.ComponentType<GameProps>;
+  loader: () => Promise<React.ComponentType<GameProps>>;
+  Component?: React.ComponentType<GameProps>;
 }


### PR DESCRIPTION
## Summary
- register games with dynamic loaders to defer component imports
- add registry helper to resolve and cache game components on demand
- update mini-games page to load components asynchronously before rendering

## Testing
- `npm test`
- `npm run check`
- ⚠️ `node --test client/src/lib/games.test.tsx` (fails: test failed)


------
https://chatgpt.com/codex/tasks/task_e_689e08f1a1608321b25364648c8bd58b