### PR TITLE
feat: add accessible emoji picker with keyboard navigation

### DIFF
--- a/client/src/components/emoji-picker.tsx
+++ b/client/src/components/emoji-picker.tsx
@@ -1,22 +1,71 @@
-import React from "react";
+import { useEffect, useRef, useState } from "react";
 
 const EMOJIS = [
-  "😀","😁","😂","🤣","😃","😄","😅","😊","😍","😎","😢","😭","😡","😱","🥳","😴","🤒","😇","🤔","🙃"
+  "😀","😁","😂","🤣","😃","😄","😅","😊","😍","😎",
+  "😢","😭","😡","😱","🥳","😴","🤒","😇","🤔","🙃"
 ];
 
 interface EmojiPickerProps {
   onSelect: (emoji: string) => void;
+  close: () => void;
 }
 
-export function EmojiPicker({ onSelect }: EmojiPickerProps) {
+export function EmojiPicker({ onSelect, close }: EmojiPickerProps) {
+  const [active, setActive] = useState(0);
+  const buttonsRef = useRef<(HTMLButtonElement | null)[]>([]);
+  const cols = 5;
+
+  useEffect(() => {
+    buttonsRef.current[active]?.focus();
+  }, [active]);
+
+  const handleKey = (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    let next = index;
+    switch (e.key) {
+      case "ArrowRight":
+        next = (index + 1) % EMOJIS.length;
+        break;
+      case "ArrowLeft":
+        next = (index - 1 + EMOJIS.length) % EMOJIS.length;
+        break;
+      case "ArrowDown":
+        next = (index + cols) % EMOJIS.length;
+        break;
+      case "ArrowUp":
+        next = (index - cols + EMOJIS.length) % EMOJIS.length;
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        onSelect(EMOJIS[index]);
+        close();
+        return;
+      case "Escape":
+        close();
+        return;
+      default:
+        return;
+    }
+    e.preventDefault();
+    setActive(next);
+  };
+
   return (
-    <div className="grid grid-cols-5 gap-2 p-2">
-      {EMOJIS.map(e => (
+    <div role="grid" aria-label="Emoji picker" className="grid grid-cols-5 gap-2 p-2">
+      {EMOJIS.map((e, i) => (
         <button
           key={e}
+          ref={el => (buttonsRef.current[i] = el)}
           type="button"
-          className="text-2xl hover:scale-110 transition-transform"
-          onClick={() => onSelect(e)}
+          role="gridcell"
+          tabIndex={i === active ? 0 : -1}
+          aria-label={e}
+          className="text-2xl hover:scale-110 transition-transform focus:outline-none focus:ring-2 focus:ring-primary rounded"
+          onClick={() => {
+            onSelect(e);
+            close();
+          }}
+          onKeyDown={ev => handleKey(ev, i)}
         >
           {e}
         </button>

--- a/client/src/components/mood-manager.tsx
+++ b/client/src/components/mood-manager.tsx
@@ -133,10 +133,8 @@ export function MoodManager({ onBack }: MoodManagerProps) {
                 </PopoverTrigger>
                 <PopoverContent className="p-0" align="start">
                   <EmojiPicker
-                    onSelect={e => {
-                      setEmoji(e);
-                      setShowPicker(false);
-                    }}
+                    onSelect={e => setEmoji(e)}
+                    close={() => setShowPicker(false)}
                   />
                 </PopoverContent>
               </Popover>
@@ -198,10 +196,8 @@ export function MoodManager({ onBack }: MoodManagerProps) {
                         </PopoverTrigger>
                         <PopoverContent className="p-0" align="start">
                           <EmojiPicker
-                            onSelect={e => {
-                              setEditEmoji(e);
-                              setShowEditPicker(false);
-                            }}
+                            onSelect={e => setEditEmoji(e)}
+                            close={() => setShowEditPicker(false)}
                           />
                         </PopoverContent>
                       </Popover>


### PR DESCRIPTION
## Summary
- redesign EmojiPicker with grid layout, keyboard navigation, and close callback
- wire MoodManager to new picker callbacks

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689e2ce5ef108321aab58d7ced17c770