### PR TITLE
feat: expand mood options and allow custom choices

### DIFF
--- a/client/public/content/moods.json
+++ b/client/public/content/moods.json
@@ -1,4 +1,4 @@
-[
+[ 
   { "emoji": "🐻", "mood": "Happy", "color": "bg-secondary-custom" },
   { "emoji": "🦊", "mood": "Calm", "color": "bg-calm-custom bg-opacity-30" },
   { "emoji": "🐢", "mood": "Tired", "color": "bg-purple-100" },
@@ -6,5 +6,20 @@
   { "emoji": "🐰", "mood": "Excited", "color": "bg-pink-100" },
   { "emoji": "🦋", "mood": "Peaceful", "color": "bg-green-100" },
   { "emoji": "🦔", "mood": "Overwhelmed", "color": "bg-red-100" },
-  { "emoji": "🐨", "mood": "Content", "color": "bg-content-custom" }
+  { "emoji": "🐨", "mood": "Content", "color": "bg-content-custom" },
+  { "emoji": "🐼", "mood": "Sad", "color": "bg-blue-100" },
+  { "emoji": "🦁", "mood": "Angry", "color": "bg-red-200" },
+  { "emoji": "🐱", "mood": "Lonely", "color": "bg-gray-200" },
+  { "emoji": "🦉", "mood": "Focused", "color": "bg-indigo-100" },
+  { "emoji": "🦥", "mood": "Bored", "color": "bg-gray-100" },
+  { "emoji": "🦩", "mood": "Silly", "color": "bg-pink-200" },
+  { "emoji": "🦚", "mood": "Proud", "color": "bg-yellow-100" },
+  { "emoji": "🐙", "mood": "Stressed", "color": "bg-rose-100" },
+  { "emoji": "🦓", "mood": "Confused", "color": "bg-slate-100" },
+  { "emoji": "🦕", "mood": "Nostalgic", "color": "bg-lime-100" },
+  { "emoji": "🐿️", "mood": "Hyper", "color": "bg-orange-200" },
+  { "emoji": "🦢", "mood": "Graceful", "color": "bg-teal-100" },
+  { "emoji": "🦜", "mood": "Chatty", "color": "bg-emerald-100" },
+  { "emoji": "🦄", "mood": "Magical", "color": "bg-fuchsia-100" },
+  { "emoji": "🐧", "mood": "Cold", "color": "bg-sky-100" }
 ]

--- a/client/src/components/mood-check-in.tsx
+++ b/client/src/components/mood-check-in.tsx
@@ -6,9 +6,10 @@ import { customMessageStore } from "@/lib/custom-message-store";
 
 interface MoodCheckInProps {
   onMoodSelected: (mood: { emoji: string; mood: string; message: string; note?: string }) => void;
+  onManageMoods?: () => void;
 }
 
-export function MoodCheckIn({ onMoodSelected }: MoodCheckInProps) {
+export function MoodCheckIn({ onMoodSelected, onManageMoods }: MoodCheckInProps) {
   const [selectedMood, setSelectedMood] = useState<{
     emoji: string;
     mood: string;
@@ -53,6 +54,17 @@ export function MoodCheckIn({ onMoodSelected }: MoodCheckInProps) {
           selectedMood={selectedMood?.mood}
           disabled={!!selectedMood}
         />
+        {onManageMoods && (
+          <div className="mt-4 text-center">
+            <button
+              type="button"
+              onClick={onManageMoods}
+              className="text-sm text-primary underline hover:no-underline focus:outline-none focus:ring-2 focus:ring-primary/50 rounded"
+            >
+              Add your own mood
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Optional note input */}

--- a/client/src/lib/content.ts
+++ b/client/src/lib/content.ts
@@ -29,6 +29,21 @@ const DEFAULT_MOODS: MoodOption[] = [
   { emoji: "🦋", mood: "Peaceful", color: "bg-green-100" },
   { emoji: "🦔", mood: "Overwhelmed", color: "bg-red-100" },
   { emoji: "🐨", mood: "Content", color: "bg-content-custom" },
+  { emoji: "🐼", mood: "Sad", color: "bg-blue-100" },
+  { emoji: "🦁", mood: "Angry", color: "bg-red-200" },
+  { emoji: "🐱", mood: "Lonely", color: "bg-gray-200" },
+  { emoji: "🦉", mood: "Focused", color: "bg-indigo-100" },
+  { emoji: "🦥", mood: "Bored", color: "bg-gray-100" },
+  { emoji: "🦩", mood: "Silly", color: "bg-pink-200" },
+  { emoji: "🦚", mood: "Proud", color: "bg-yellow-100" },
+  { emoji: "🐙", mood: "Stressed", color: "bg-rose-100" },
+  { emoji: "🦓", mood: "Confused", color: "bg-slate-100" },
+  { emoji: "🦕", mood: "Nostalgic", color: "bg-lime-100" },
+  { emoji: "🐿️", mood: "Hyper", color: "bg-orange-200" },
+  { emoji: "🦢", mood: "Graceful", color: "bg-teal-100" },
+  { emoji: "🦜", mood: "Chatty", color: "bg-emerald-100" },
+  { emoji: "🦄", mood: "Magical", color: "bg-fuchsia-100" },
+  { emoji: "🐧", mood: "Cold", color: "bg-sky-100" },
 ];
 
 async function fetchJson<T>(path: string): Promise<T> {

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -64,7 +64,10 @@ export default function Home() {
       <main id="main-content" role="main">
         {currentView === "checkIn" ? (
           <>
-            <MoodCheckIn onMoodSelected={handleMoodSelected} />
+            <MoodCheckIn
+              onMoodSelected={handleMoodSelected}
+              onManageMoods={() => setCurrentView("moodManager")}
+            />
             <div className="px-6 pb-6">
               <MiniGamesPreview />
             </div>


### PR DESCRIPTION
## Summary
- add many new default mood options with friendly emoji palette
- allow users to jump to mood manager from check-in to create their own moods

## Testing
- `npm test`
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e34c91fa4832190a795d3cb4de0f4