### PR TITLE
feat: add Chatwoot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Everything stays on your device because your emotional data is deeply personal.
 - [📚 Full Docs](docs/README.md)
 - [🎨 Mood Customization](docs/mood-customization.md)
 - [📝 Content Management](#-content-management)
+- [💬 Support](#-support)
 
 ---
 
@@ -204,6 +205,15 @@ That's it! 🎉 No database setup, no API keys, no complicated configuration.
 ```bash
 npm test
 ```
+
+## 💬 Support
+
+Need help or have questions? Every page includes a Chatwoot widget for quick support. Configure your deployment with these environment variables so the widget can connect to your Chatwoot instance:
+
+- `VITE_CHATWOOT_WEBSITE_TOKEN`
+- `VITE_CHATWOOT_HOST_URL`
+
+You can self-host Chatwoot or sign up for a hosted service and then supply the token and host URL above.
 
 ## 🏭 Production Install
 

--- a/client/index.html
+++ b/client/index.html
@@ -21,5 +21,19 @@
   <body>
     <div id="root"></div>
 <script type="module" src="/src/main.tsx"></script>
+    <script>
+      (function(d, t) {
+        var BASE_URL = "%VITE_CHATWOOT_HOST_URL%";
+        var g = d.createElement(t), s = d.getElementsByTagName(t)[0];
+        g.src = BASE_URL + "/packs/js/sdk.js";
+        s.parentNode.insertBefore(g, s);
+        g.onload = function() {
+          window.chatwootSDK.run({
+            websiteToken: "%VITE_CHATWOOT_WEBSITE_TOKEN%",
+            baseUrl: BASE_URL
+          });
+        };
+      })(document, "script");
+    </script>
   </body>
 </html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,8 @@
 
 [build.environment]
   NODE_VERSION = "18"
+  VITE_CHATWOOT_WEBSITE_TOKEN = ""
+  VITE_CHATWOOT_HOST_URL = ""
 
 # SPA routing for the main app
 [[redirects]]


### PR DESCRIPTION
## Summary
- embed Chatwoot widget on every page
- document Chatwoot support channel and required env vars
- add Chatwoot env vars to Netlify config

## Testing
- `npm test`
- `VITE_CHATWOOT_WEBSITE_TOKEN=token VITE_CHATWOOT_HOST_URL=https://chat.example npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e3537547083218ea73034d666b24f