### PR TITLE
feat: add chatwoot widget to support page

### DIFF
--- a/client/src/pages/support.tsx
+++ b/client/src/pages/support.tsx
@@ -1,6 +1,25 @@
+import { useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 
 const Support = () => {
+  useEffect(() => {
+    (function (d, t) {
+      var BASE_URL = "https://app.chatwoot.com";
+      var g = d.createElement(t),
+        s = d.getElementsByTagName(t)[0];
+      g.src = BASE_URL + "/packs/js/sdk.js";
+      g.async = true;
+      s.parentNode.insertBefore(g, s);
+      g.onload = function () {
+        // @ts-ignore
+        window.chatwootSDK.run({
+          websiteToken: "DwYjbjX3oedt2ZPeTKZqBqmE",
+          baseUrl: BASE_URL,
+        });
+      };
+    })(document, "script");
+  }, []);
+
   return (
     <div className="min-h-screen w-full flex items-center justify-center bg-gray-50">
       <Card className="w-full max-w-md mx-4">


### PR DESCRIPTION
## Summary
- load Chatwoot script on support page for live chat support

## Testing
- `npm test`
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68a2631b0ea08321a3a8ae6822da07d3