### PR TITLE
Add animal-themed checkers and chess mini-games

### DIFF
--- a/client/src/games/animal-checkers.tsx
+++ b/client/src/games/animal-checkers.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { GameProps } from '@/types/game';
+import { Button } from '@/components/ui/button';
+
+type Piece = 'fox' | 'bunny';
+const BOARD_SIZE = 8;
+
+const pieceEmoji: Record<Piece, string> = {
+  fox: '🦊',
+  bunny: '🐰'
+};
+
+function createInitialBoard(): (Piece | null)[][] {
+  return Array.from({ length: BOARD_SIZE }, (_, r) =>
+    Array.from({ length: BOARD_SIZE }, (_, c) => {
+      if (r < 3 && (r + c) % 2 === 1) return 'fox';
+      if (r > 4 && (r + c) % 2 === 1) return 'bunny';
+      return null;
+    })
+  );
+}
+
+export function AnimalCheckers({ onComplete, onExit, config }: GameProps) {
+  const [board, setBoard] = useState<(Piece | null)[][]>(createInitialBoard);
+  const [selected, setSelected] = useState<[number, number] | null>(null);
+  const [player, setPlayer] = useState<Piece>('fox');
+
+  const handleCellClick = (r: number, c: number) => {
+    const cell = board[r][c];
+
+    if (selected) {
+      const [sr, sc] = selected;
+      if (board[r][c] === null && isValidMove(sr, sc, r, c)) {
+        const newBoard = board.map(row => [...row]);
+        newBoard[r][c] = board[sr][sc];
+        newBoard[sr][sc] = null;
+        if (Math.abs(r - sr) === 2) {
+          const mr = (r + sr) / 2;
+          const mc = (c + sc) / 2;
+          newBoard[mr][mc] = null;
+        }
+        setBoard(newBoard);
+        setPlayer(prev => (prev === 'fox' ? 'bunny' : 'fox'));
+      }
+      setSelected(null);
+      return;
+    }
+
+    if (cell === player) {
+      setSelected([r, c]);
+    }
+  };
+
+  const isValidMove = (sr: number, sc: number, r: number, c: number) => {
+    const dir = player === 'fox' ? 1 : -1;
+    const dr = r - sr;
+    const dc = c - sc;
+
+    if (dr === dir && Math.abs(dc) === 1) return true;
+    if (dr === 2 * dir && Math.abs(dc) === 2) {
+      const mr = sr + dir;
+      const mc = sc + dc / 2;
+      const middle = board[mr][mc];
+      if (middle && middle !== player) return true;
+    }
+    return false;
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[400px] p-6 bg-gradient-to-br from-amber-50 to-lime-50 dark:from-amber-900/20 dark:to-lime-900/20 rounded-2xl">
+      <div className="text-center mb-4">
+        <div className="text-2xl mb-2">{config.emoji}</div>
+        <h2 className="text-xl font-bold text-foreground mb-2">{config.name}</h2>
+        <p className="text-sm text-muted-foreground mb-2">{config.description}</p>
+        <p className="text-sm text-muted-foreground">Current player: {pieceEmoji[player]}</p>
+      </div>
+      <div className="grid grid-cols-8 gap-1 mb-6">
+        {board.map((row, r) =>
+          row.map((cell, c) => {
+            const isDark = (r + c) % 2 === 1;
+            const isSel = selected && selected[0] === r && selected[1] === c;
+            return (
+              <button
+                key={`${r}-${c}`}
+                onClick={() => handleCellClick(r, c)}
+                aria-label={cell ? `${cell} piece` : 'empty square'}
+                className={`w-10 h-10 flex items-center justify-center text-xl rounded ${isDark ? 'bg-amber-200 dark:bg-amber-600' : 'bg-lime-200 dark:bg-lime-600'} ${isSel ? 'ring-2 ring-offset-2 ring-blue-400' : ''}`}
+              >
+                {cell ? pieceEmoji[cell] : ''}
+              </button>
+            );
+          })
+        )}
+      </div>
+      <div className="flex gap-3">
+        <Button
+          onClick={() => onComplete?.({ completed: true, timeSpent: 0, moodImpact: 'calming' })}
+          variant="outline"
+        >
+          Complete
+        </Button>
+        <Button onClick={onExit} variant="ghost">
+          Exit
+        </Button>
+      </div>
+    </div>
+  );
+}
+

--- a/client/src/games/animal-chess.tsx
+++ b/client/src/games/animal-chess.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import { GameProps } from '@/types/game';
+import { Button } from '@/components/ui/button';
+
+const BOARD_SIZE = 8;
+
+const pieceEmoji: Record<string, string> = {
+  r: '🦊',
+  n: '🦝',
+  b: '🦉',
+  q: '🦁',
+  k: '🐻',
+  p: '🐭',
+  R: '🐰',
+  N: '🦄',
+  B: '🐼',
+  Q: '🐱',
+  K: '🐶',
+  P: '🐹'
+};
+
+function createInitialBoard(): (string | null)[][] {
+  return [
+    ['r', 'n', 'b', 'q', 'k', 'b', 'n', 'r'],
+    Array(8).fill('p'),
+    Array(8).fill(null),
+    Array(8).fill(null),
+    Array(8).fill(null),
+    Array(8).fill(null),
+    Array(8).fill('P'),
+    ['R', 'N', 'B', 'Q', 'K', 'B', 'N', 'R']
+  ];
+}
+
+function isWhite(piece: string | null) {
+  return piece ? piece === piece.toUpperCase() : false;
+}
+
+export function AnimalChess({ onComplete, onExit, config }: GameProps) {
+  const [board, setBoard] = useState<(string | null)[][]>(createInitialBoard);
+  const [selected, setSelected] = useState<[number, number] | null>(null);
+  const [player, setPlayer] = useState<'white' | 'black'>('white');
+
+  const handleCellClick = (r: number, c: number) => {
+    const piece = board[r][c];
+
+    if (selected) {
+      const [sr, sc] = selected;
+      const movingPiece = board[sr][sc];
+      const target = board[r][c];
+      if (movingPiece && (target === null || isWhite(movingPiece) !== isWhite(target))) {
+        const newBoard = board.map(row => [...row]);
+        newBoard[r][c] = movingPiece;
+        newBoard[sr][sc] = null;
+        setBoard(newBoard);
+        setPlayer(prev => (prev === 'white' ? 'black' : 'white'));
+      }
+      setSelected(null);
+      return;
+    }
+
+    if (piece && ((player === 'white' && isWhite(piece)) || (player === 'black' && !isWhite(piece)))) {
+      setSelected([r, c]);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[400px] p-6 bg-gradient-to-br from-slate-50 to-stone-50 dark:from-slate-900/20 dark:to-stone-900/20 rounded-2xl">
+      <div className="text-center mb-4">
+        <div className="text-2xl mb-2">{config.emoji}</div>
+        <h2 className="text-xl font-bold text-foreground mb-2">{config.name}</h2>
+        <p className="text-sm text-muted-foreground mb-2">{config.description}</p>
+        <p className="text-sm text-muted-foreground">Current player: {player === 'white' ? '🐹' : '🐭'}</p>
+      </div>
+      <div className="grid grid-cols-8 gap-1 mb-6">
+        {board.map((row, r) =>
+          row.map((cell, c) => {
+            const isDark = (r + c) % 2 === 1;
+            const isSel = selected && selected[0] === r && selected[1] === c;
+            return (
+              <button
+                key={`${r}-${c}`}
+                onClick={() => handleCellClick(r, c)}
+                aria-label={cell ? `piece ${cell}` : 'empty square'}
+                className={`w-10 h-10 flex items-center justify-center text-xl rounded ${isDark ? 'bg-slate-300 dark:bg-slate-600' : 'bg-stone-200 dark:bg-stone-600'} ${isSel ? 'ring-2 ring-offset-2 ring-blue-400' : ''}`}
+              >
+                {cell ? pieceEmoji[cell] : ''}
+              </button>
+            );
+          })
+        )}
+      </div>
+      <div className="flex gap-3">
+        <Button
+          onClick={() => onComplete?.({ completed: true, timeSpent: 0, moodImpact: 'calming' })}
+          variant="outline"
+        >
+          Complete
+        </Button>
+        <Button onClick={onExit} variant="ghost">
+          Exit
+        </Button>
+      </div>
+    </div>
+  );
+}
+

--- a/client/src/games/index.ts
+++ b/client/src/games/index.ts
@@ -6,6 +6,8 @@ export { DrawingPad } from './drawing-pad';
 export { ShapeMatch } from './shape-match';
 export { ZenBlocks } from './zen-blocks';
 export { BubblePop } from './bubble-pop';
+export { AnimalCheckers } from './animal-checkers';
+export { AnimalChess } from './animal-chess';
 
 // This file makes it easier to add new games in the future
 // Just export them here and register them in lib/games.ts

--- a/client/src/lib/games.test.tsx
+++ b/client/src/lib/games.test.tsx
@@ -28,6 +28,20 @@ test('bubble-pop game registered under calming category', () => {
   assert.equal(game!.config.category, 'calming');
 });
 
+// Verify animal-checkers game is registered correctly
+test('animal-checkers game registered under focus category', () => {
+  const game = gameRegistry.getGame('animal-checkers');
+  assert.ok(game, 'animal-checkers game should be registered');
+  assert.equal(game!.config.category, 'focus');
+});
+
+// Verify animal-chess game is registered correctly
+test('animal-chess game registered under focus category', () => {
+  const game = gameRegistry.getGame('animal-chess');
+  assert.ok(game, 'animal-chess game should be registered');
+  assert.equal(game!.config.category, 'focus');
+});
+
 // Verify MiniGames renders the shape-match card
 
 test('MiniGames lists the Shape Match game', () => {

--- a/client/src/lib/games.ts
+++ b/client/src/lib/games.ts
@@ -6,6 +6,8 @@ import { ShapeMatch } from '@/games/shape-match';
 import { ZenBlocks } from '@/games/zen-blocks';
 import { CritterCare } from '@/games/critter-care';
 import { BubblePop } from '@/games/bubble-pop';
+import { AnimalCheckers } from '@/games/animal-checkers';
+import { AnimalChess } from '@/games/animal-chess';
 
 // Register all games
 gameRegistry.register({
@@ -140,6 +142,45 @@ gameRegistry.register({
   },
   Component: BubblePop
 });
+
+gameRegistry.register({
+  config: {
+    id: 'animal-checkers',
+    name: 'Critter Checkers',
+    description: 'Friendly foxes and bunnies play a gentle game of checkers.',
+    emoji: '🦊',
+    category: 'focus',
+    difficulty: 'easy',
+    estimatedTime: '5-15 min',
+    accessibility: {
+      motionSensitive: false,
+      soundRequired: false,
+      colorBlindFriendly: true
+    },
+    tags: ['board', 'strategy', 'animals', 'checkers']
+  },
+  Component: AnimalCheckers
+});
+
+gameRegistry.register({
+  config: {
+    id: 'animal-chess',
+    name: 'Critter Chess',
+    description: 'A calm chessboard with animal pieces you can move at your own pace.',
+    emoji: '🦉',
+    category: 'focus',
+    difficulty: 'medium',
+    estimatedTime: '10-30 min',
+    accessibility: {
+      motionSensitive: false,
+      soundRequired: false,
+      colorBlindFriendly: true
+    },
+    tags: ['board', 'strategy', 'animals', 'chess']
+  },
+  Component: AnimalChess
+});
+
 
 // Export the registry for use in components
 export { gameRegistry };


### PR DESCRIPTION
## Summary
- introduce ND-friendly Critter Checkers with fox and bunny pieces
- add Critter Chess board using playful animal pieces
- register new games and extend tests

## Testing
- `npm test`
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68a53bf7f4848321bc6621d20562a01a