### PR TITLE
fix: drop node type requirement

### DIFF
--- a/client/src/components/error-boundary.tsx
+++ b/client/src/components/error-boundary.tsx
@@ -81,7 +81,7 @@ export function ErrorBoundary({ children, fallback }: Props) {
             </p>
           </div>
 
-          {process.env.NODE_ENV === 'development' && error && (
+          {import.meta.env.DEV && error && (
             <details className="mt-4 text-left">
               <summary className="text-xs text-muted-foreground cursor-pointer">
                 Technical details (dev mode)

--- a/client/src/games/breathing-bubble.tsx
+++ b/client/src/games/breathing-bubble.tsx
@@ -8,7 +8,7 @@ export function BreathingBubble({ onComplete, onExit, config }: GameProps) {
   const [phase, setPhase] = useState<'inhale' | 'hold' | 'exhale' | 'rest'>('inhale');
   const [cycles, setCycles] = useState(0);
   const [timeElapsed, setTimeElapsed] = useState(0);
-  const intervalRef = useRef<NodeJS.Timeout>();
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const startTime = useRef<number>(Date.now());
 
   const phaseDurations = {

--- a/client/src/lib/accessibility-audit.ts
+++ b/client/src/lib/accessibility-audit.ts
@@ -92,6 +92,6 @@ function checkColorContrast(): string[] {
 }
 
 // Export for use in development
-if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
+if (typeof window !== 'undefined' && import.meta.env.DEV) {
   (window as any).runAccessibilityAudit = runAccessibilityAudit;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
         "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
         "@tailwindcss/typography": "^0.5.15",
         "@tailwindcss/vite": "^4.1.3",
-        "@types/node": "20.16.11",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.2",
@@ -2934,6 +2933,8 @@
       "integrity": "sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -5657,7 +5658,9 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.1.3",
-    "@types/node": "20.16.11",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["client/src/**/*", "shared/**/*"],
-  "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
+  "exclude": ["node_modules", "build", "dist", "**/*.test.ts", "**/*.test.tsx"],
   "compilerOptions": {
     "incremental": true,
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",
@@ -15,7 +15,7 @@
     "allowImportingTsExtensions": true,
     "moduleResolution": "bundler",
     "baseUrl": ".",
-    "types": ["node", "vite/client"],
+    "types": ["vite/client"],
     "paths": {
       "@/*": ["./client/src/*"],
       "@shared/*": ["./shared/*"]


### PR DESCRIPTION
## Summary
- remove dependency on Node types by using `import.meta.env` and generic timer types
- exclude test files and drop `node` types from TypeScript config
- clean up dev dependencies

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a53ee44be08321af27febc20246e17