### PR TITLE
feat: add chess engine with cpu moves

### DIFF
--- a/client/src/games/animal-chess.test.ts
+++ b/client/src/games/animal-chess.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Chess } from 'chess.js';
+import { performCpuMove } from '@/games/animal-chess';
+
+test('performCpuMove makes a valid move for black and updates board', () => {
+  const game = new Chess();
+  game.move('e4');
+  const before = game.fen();
+  const move = performCpuMove(game);
+  assert.ok(move, 'CPU should make a move');
+  assert.notEqual(game.fen(), before, 'Board should change after CPU move');
+  assert.equal(game.turn(), 'w', 'Turn should pass back to white');
+});
+
+test('performCpuMove returns null when no legal moves', () => {
+  const game = new Chess('7k/5Q2/7K/8/8/8/8/8 b - - 0 1');
+  const move = performCpuMove(game);
+  assert.equal(move, null);
+});

--- a/client/src/lib/games.ts
+++ b/client/src/lib/games.ts
@@ -166,7 +166,7 @@ gameRegistry.register({
   config: {
     id: 'animal-chess',
     name: 'Critter Chess',
-    description: 'A calm chessboard with animal pieces you can move at your own pace.',
+    description: 'A calm chessboard with animal pieces and a gentle CPU opponent.',
     emoji: '🦉',
     category: 'focus',
     difficulty: 'medium',

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "vite build && node scripts/copy-content.js",
     "preview": "vite preview",
     "check": "tsc",
-    "test": "echo \"No tests\""
+    "test": "node --import tsx --test client/src/**/*.test.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -66,7 +66,8 @@
     "vaul": "^1.1.2",
     "wouter": "^3.3.5",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "chess.js": "^1.0.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.8",


### PR DESCRIPTION
## Summary
- integrate chess.js to handle move legality and board state
- add random CPU opponent for Animal Chess and corresponding tests
- document CPU opponent in game registry

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/chess.js)*
- `npm test` *(fails: Cannot find package 'chess.js')*
- `npm run check` *(fails: Cannot find module 'chess.js')*

------
https://chatgpt.com/codex/tasks/task_e_68a53f9ff46083219474e7905543c4b0